### PR TITLE
Fix Phase 1-4 create payload shapes to match backend schemas

### DIFF
--- a/packages/data-provider/src/providers/resourceRegistry.test.ts
+++ b/packages/data-provider/src/providers/resourceRegistry.test.ts
@@ -93,4 +93,30 @@ describe('resourceRegistry', () => {
     const result = getResourceBySchema('ACCESSCONTROL-ROLEACTIONS.roleactions');
     assert.strictEqual(result, 'role-actions');
   });
+
+  it('covers schemas registered on ke tenant that previously had no UI', () => {
+    // Pin Stage-0 hygiene: these 7 schemas live on `ke` but were invisible in
+    // the configurator before. If a future refactor drops one, this fails loud.
+    const expected: Record<string, string> = {
+      'theme-config': 'common-masters.ThemeConfig',
+      'user-validation': 'common-masters.UserValidation',
+      'mobile-validation': 'ValidationConfigs.mobileNumberValidation',
+      'tenant-boundary': 'egov-location.TenantBoundary',
+      'auto-escalation-ignore': 'Workflow.AutoEscalationStatesToIgnore',
+      'workflow-bs-master': 'Workflow.BusinessServiceMasterConfig',
+      'pgr-ui-constants': 'RAINMAKER-PGR.UIConstants',
+    };
+    for (const [resource, schema] of Object.entries(expected)) {
+      const cfg = getResourceConfig(resource);
+      assert.ok(cfg, `Missing resource ${resource}`);
+      assert.strictEqual(cfg.schema, schema, `${resource} should point to ${schema}`);
+    }
+  });
+
+  it('does not register schemas that do not exist on ke (phantom cleanup)', () => {
+    // `tenant.branding` is not registered on `ke` — the previous `branding`
+    // entry 404'd. Keep this assertion until branding becomes a real schema.
+    assert.strictEqual(getResourceBySchema('tenant.branding'), undefined);
+    assert.strictEqual(getResourceConfig('branding'), undefined);
+  });
 });

--- a/packages/data-provider/src/providers/resourceRegistry.ts
+++ b/packages/data-provider/src/providers/resourceRegistry.ts
@@ -87,7 +87,6 @@ export const REGISTRY: Record<string, ResourceConfig> = {
 
   // Generic MDMS Resources
   'state-info': { type: 'mdms', label: 'State Info', schema: 'common-masters.StateInfo', idField: 'code', nameField: 'name' },
-  branding: { type: 'mdms', label: 'Tenant Branding', schema: 'tenant.branding', idField: 'code', nameField: 'name' },
   'city-modules': { type: 'mdms', label: 'City Modules', schema: 'tenant.citymodule', idField: 'code', nameField: 'module' },
   'id-formats': { type: 'mdms', label: 'ID Formats', schema: 'common-masters.IdFormat', idField: 'idname', nameField: 'idname' },
   'workflow-services': { type: 'mdms', label: 'Business Services', schema: 'Workflow.BusinessService', idField: 'businessService', nameField: 'business' },
@@ -111,6 +110,17 @@ export const REGISTRY: Record<string, ResourceConfig> = {
   'employee-type': { type: 'mdms', label: 'Employee Type', schema: MDMS_SCHEMAS.EMPLOYEE_TYPE, idField: 'code', nameField: 'code' },
   'cron-jobs': { type: 'mdms', label: 'Cron Jobs', schema: 'common-masters.CronJobAPIConfig', idField: 'jobName', nameField: 'jobName' },
   'ui-homepage': { type: 'mdms', label: 'UI Homepage', schema: 'common-masters.uiHomePage', idField: 'redirectURL', nameField: 'redirectURL' },
+
+  // Added by Stage-0 registry hygiene: schemas live on `ke` but had no UI surface.
+  // These get the same generic CRUD as the entries above; richer per-field widgets
+  // are layered on later via src/admin/schemaDescriptors/ (Stage 1+).
+  'theme-config':           { type: 'mdms', label: 'Theme Config',             schema: 'common-masters.ThemeConfig',               idField: 'code',              nameField: 'name' },
+  'user-validation':        { type: 'mdms', label: 'User Field Validation',    schema: 'common-masters.UserValidation',            idField: 'fieldType',         nameField: 'fieldType' },
+  'mobile-validation':      { type: 'mdms', label: 'Mobile Number Validation', schema: 'ValidationConfigs.mobileNumberValidation', idField: 'validationName',    nameField: 'validationName' },
+  'tenant-boundary':        { type: 'mdms', label: 'Tenant Boundary (HRMS)',   schema: 'egov-location.TenantBoundary',             idField: 'hierarchyType.code', nameField: 'hierarchyType.code' },
+  'auto-escalation-ignore': { type: 'mdms', label: 'Auto-Escalation Ignored',  schema: 'Workflow.AutoEscalationStatesToIgnore',    idField: 'businessService',   nameField: 'businessService' },
+  'workflow-bs-master':     { type: 'mdms', label: 'Workflow BS Master',       schema: 'Workflow.BusinessServiceMasterConfig',     idField: 'active',            nameField: 'businessService' },
+  'pgr-ui-constants':       { type: 'mdms', label: 'PGR UI Constants',         schema: 'RAINMAKER-PGR.UIConstants',                idField: 'REOPENSLA',         nameField: 'REOPENSLA' },
 };
 
 export function getResourceConfig(resource: string): ResourceConfig | undefined {

--- a/src/admin/DigitFormInput.tsx
+++ b/src/admin/DigitFormInput.tsx
@@ -14,6 +14,8 @@ export interface DigitFormInputProps extends InputProps {
   disabled?: boolean;
   /** Additional CSS class names for the wrapper */
   className?: string;
+  /** Optional helper text shown below the input (muted) */
+  help?: string;
 }
 
 export function DigitFormInput({
@@ -22,6 +24,7 @@ export function DigitFormInput({
   type = 'text',
   disabled = false,
   className,
+  help,
   ...inputProps
 }: DigitFormInputProps) {
   // Auto-coerce number inputs so the form value is a number, not a string
@@ -70,6 +73,9 @@ export function DigitFormInput({
         >
           {errorMessage}
         </p>
+      )}
+      {!hasError && help && (
+        <p className="mt-1 text-xs text-muted-foreground">{help}</p>
       )}
     </div>
   );

--- a/src/admin/MdmsResourceCreate.tsx
+++ b/src/admin/MdmsResourceCreate.tsx
@@ -1,51 +1,35 @@
 import { useMemo } from 'react';
 import { DigitCreate } from './DigitCreate';
 import { DigitFormInput } from './DigitFormInput';
+import { WidgetForFieldSpec } from './widgets';
 import { useResourceContext, useInput, required } from 'ra-core';
 import { getResourceConfig, getResourceLabel } from '@/providers/bridge';
 import { useSchemaDefinition } from '@/hooks/useSchemaDefinition';
 import { orderFields, formatFieldLabel } from './schemaUtils';
 import { Label } from '@/components/ui/label';
+import { getDescriptor } from './schemaDescriptors';
+import type { SchemaDescriptor } from './schemaDescriptors/types';
 import type { SchemaDefinition, SchemaProperty } from './schemaUtils';
 
-/** Derive HTML input type from JSON Schema property */
 function inputType(prop: SchemaProperty): string {
   if (prop.type === 'number' || prop.type === 'integer') return 'number';
   if (prop.format === 'email') return 'email';
   return 'text';
 }
 
-/** Check if a property is a complex type (array/object) */
 function isComplex(prop: SchemaProperty): boolean {
   return prop.type === 'array' || prop.type === 'object';
 }
 
-/** Build default record values from schema */
 function buildDefaults(definition: SchemaDefinition): Record<string, unknown> {
   const defaults: Record<string, unknown> = {};
   const props = definition.properties ?? {};
   for (const [key, prop] of Object.entries(props)) {
-    if (prop.type === 'boolean') {
-      defaults[key] = key === 'active' ? true : false;
-    }
+    if (prop.type === 'boolean') defaults[key] = key === 'active' ? true : false;
   }
   return defaults;
 }
 
-/** Count required complex fields that won't appear in the form */
-function getMissingComplexFields(definition: SchemaDefinition): string[] {
-  const requiredSet = new Set(definition.required ?? []);
-  const props = definition.properties ?? {};
-  const missing: string[] = [];
-  for (const [key, prop] of Object.entries(props)) {
-    if (requiredSet.has(key) && isComplex(prop)) {
-      missing.push(key);
-    }
-  }
-  return missing;
-}
-
-/** Simple boolean checkbox input for react-admin forms */
 function BooleanInput({ source, label }: { source: string; label: string }) {
   const { id, field } = useInput({ source, parse: (v: boolean) => v });
   return (
@@ -65,22 +49,42 @@ function BooleanInput({ source, label }: { source: string; label: string }) {
   );
 }
 
-function MdmsCreateFields({ definition }: { definition: SchemaDefinition }) {
+function MdmsCreateFields({
+  definition,
+  descriptor,
+}: {
+  definition: SchemaDefinition;
+  descriptor?: SchemaDescriptor;
+}) {
   const requiredSet = useMemo(() => new Set(definition.required ?? []), [definition]);
   const ordered = useMemo(() => orderFields(definition), [definition]);
-  const missingComplex = useMemo(() => getMissingComplexFields(definition), [definition]);
   const props = definition.properties ?? {};
+
+  // 1. Render descriptor-defined fields first (includes nested paths the JSON
+  //    Schema skips as "complex objects").
+  const descriptorPaths = new Set(descriptor?.fields.map((f) => f.path) ?? []);
+  const groupedOrder = descriptor?.groups?.flatMap((g) => g.fields) ?? [];
+  const descriptorFields = descriptor
+    ? [...groupedOrder, ...(descriptor.fields.map((f) => f.path).filter((p) => !groupedOrder.includes(p)))]
+    : [];
 
   return (
     <>
+      {/* descriptor-defined widgets */}
+      {descriptorFields.map((path) => {
+        const spec = descriptor?.fields.find((f) => f.path === path);
+        if (!spec || spec.hidden === 'create' || spec.hidden === 'always') return null;
+        return <WidgetForFieldSpec key={path} spec={spec} source={path} />;
+      })}
+
+      {/* JSON-Schema-driven scalar fallbacks for anything the descriptor didn't cover */}
       {ordered.map((field) => {
+        if (descriptorPaths.has(field)) return null;
         const prop = props[field];
         if (!prop || isComplex(prop)) return null;
-
         if (prop.type === 'boolean') {
           return <BooleanInput key={field} source={field} label={formatFieldLabel(field)} />;
         }
-
         return (
           <DigitFormInput
             key={field}
@@ -91,11 +95,6 @@ function MdmsCreateFields({ definition }: { definition: SchemaDefinition }) {
           />
         );
       })}
-      {missingComplex.length > 0 && (
-        <p className="text-xs text-muted-foreground mt-2">
-          Note: This schema also requires {missingComplex.map(f => formatFieldLabel(f)).join(', ')} (complex fields) which must be added via API.
-        </p>
-      )}
     </>
   );
 }
@@ -105,6 +104,7 @@ export function MdmsResourceCreate() {
   const config = getResourceConfig(resource);
   const label = getResourceLabel(resource);
   const { definition } = useSchemaDefinition(config?.schema);
+  const descriptor = getDescriptor(config?.schema);
 
   const defaults = useMemo(() => {
     if (!definition) return undefined;
@@ -121,7 +121,7 @@ export function MdmsResourceCreate() {
 
   return (
     <DigitCreate title={`Create ${label}`} record={defaults}>
-      <MdmsCreateFields definition={definition} />
+      <MdmsCreateFields definition={definition} descriptor={descriptor} />
     </DigitCreate>
   );
 }

--- a/src/admin/MdmsResourceEdit.tsx
+++ b/src/admin/MdmsResourceEdit.tsx
@@ -1,27 +1,45 @@
 import { DigitEdit } from './DigitEdit';
 import { DigitFormInput } from './DigitFormInput';
+import { WidgetForFieldSpec } from './widgets';
 import { useEditContext, useResourceContext } from 'ra-core';
 import { getResourceConfig, getResourceLabel } from '@/providers/bridge';
+import { getDescriptor } from './schemaDescriptors';
 
 function MdmsEditFields() {
   const resource = useResourceContext() ?? '';
   const config = getResourceConfig(resource);
   const idField = config?.idField ?? 'id';
+  const descriptor = getDescriptor(config?.schema);
   const { record } = useEditContext();
 
   if (!record) return null;
 
-  const keys = Object.keys(record as Record<string, unknown>)
-    .filter((k) => !k.startsWith('_') && k !== 'id');
+  // 1. Render descriptor-defined fields first (including nested paths).
+  const descriptorPaths = new Set(descriptor?.fields.map((f) => f.path) ?? []);
+  const groupedOrder = descriptor?.groups?.flatMap((g) => g.fields) ?? [];
+  const descriptorFields = descriptor
+    ? [...groupedOrder, ...(descriptor.fields.map((f) => f.path).filter((p) => !groupedOrder.includes(p)))]
+    : [];
+
+  // 2. Fall back to the existing generic loop for everything else.
+  const topLevelKeys = Object.keys(record as Record<string, unknown>)
+    .filter((k) => !k.startsWith('_') && k !== 'id')
+    .filter((k) => !descriptorPaths.has(k));
 
   return (
     <>
-      {keys.map((key) => {
+      {descriptorFields.map((path) => {
+        const spec = descriptor?.fields.find((f) => f.path === path);
+        if (!spec || spec.hidden === 'edit' || spec.hidden === 'always') return null;
+        return <WidgetForFieldSpec key={path} spec={spec} source={path} />;
+      })}
+
+      {topLevelKeys.map((key) => {
         const value = (record as Record<string, unknown>)[key];
         const displayKey = key.replace(/([A-Z])/g, ' $1').replace(/^./, (s) => s.toUpperCase());
         const isId = key === idField;
 
-        // Skip complex objects for now
+        // Skip complex objects the descriptor didn't handle — same behavior as before.
         if (value != null && typeof value === 'object') return null;
 
         return (
@@ -41,7 +59,6 @@ function MdmsEditFields() {
 export function MdmsResourceEdit() {
   const resource = useResourceContext() ?? '';
   const label = getResourceLabel(resource);
-
   return (
     <DigitEdit title={`Edit ${label}`}>
       <MdmsEditFields />

--- a/src/admin/schemaDescriptors/auto-escalation-ignore.ts
+++ b/src/admin/schemaDescriptors/auto-escalation-ignore.ts
@@ -1,0 +1,29 @@
+import type { SchemaDescriptor } from './types';
+
+/**
+ * Descriptor for `Workflow.AutoEscalationStatesToIgnore`.
+ *
+ * Each record names a workflow (businessService + module) and the set of
+ * states the auto-escalation cron should skip. The JSON Schema declares
+ * `state` as `array<string>`, which the default auto-form would skip, so
+ * this descriptor wires it to the `chip-array` widget.
+ *
+ * Note: `businessService` is `x-unique` on the schema, so it also serves as
+ * the record's unique identifier. It must match an existing
+ * `Workflow.BusinessService` code or the cron will silently no-op.
+ */
+export const autoEscalationIgnoreDescriptor: SchemaDescriptor = {
+  schema: 'Workflow.AutoEscalationStatesToIgnore',
+  groups: [
+    { title: 'Scope', fields: ['businessService', 'module'] },
+    { title: 'Ignored states', fields: ['state'] },
+  ],
+  fields: [
+    { path: 'businessService', widget: 'text', required: true,
+      help: 'Must match a Workflow.BusinessService code (e.g. "NewTL"). Becomes the record\'s unique identifier.' },
+    { path: 'module', widget: 'text', required: true,
+      help: 'The module that owns this workflow (e.g. "TL").' },
+    { path: 'state', widget: 'chip-array', label: 'States to ignore',
+      help: 'Workflow states the escalation cron should skip, e.g. INITIATED, PENDINGAPPROVAL. Match the state\'s `state` field, not its name.' },
+  ],
+};

--- a/src/admin/schemaDescriptors/index.ts
+++ b/src/admin/schemaDescriptors/index.ts
@@ -1,0 +1,18 @@
+import type { SchemaDescriptor } from './types';
+import { userValidationDescriptor } from './user-validation';
+
+/** Map of schema code -> descriptor. Add new entries as we cover more schemas. */
+const DESCRIPTORS: Record<string, SchemaDescriptor> = {
+  [userValidationDescriptor.schema]: userValidationDescriptor,
+};
+
+export function getDescriptor(schemaCode?: string): SchemaDescriptor | undefined {
+  if (!schemaCode) return undefined;
+  return DESCRIPTORS[schemaCode];
+}
+
+export function getFieldSpec(descriptor: SchemaDescriptor | undefined, path: string) {
+  return descriptor?.fields.find((f) => f.path === path);
+}
+
+export type { SchemaDescriptor, FieldSpec, FieldGroup, WidgetKind } from './types';

--- a/src/admin/schemaDescriptors/index.ts
+++ b/src/admin/schemaDescriptors/index.ts
@@ -1,9 +1,21 @@
 import type { SchemaDescriptor } from './types';
 import { userValidationDescriptor } from './user-validation';
+import { mobileValidationDescriptor } from './mobile-validation';
+import { themeConfigDescriptor } from './theme-config';
+import { tenantBoundaryDescriptor } from './tenant-boundary';
+import { autoEscalationIgnoreDescriptor } from './auto-escalation-ignore';
+import { workflowBsMasterDescriptor } from './workflow-bs-master';
+import { pgrUiConstantsDescriptor } from './pgr-ui-constants';
 
 /** Map of schema code -> descriptor. Add new entries as we cover more schemas. */
 const DESCRIPTORS: Record<string, SchemaDescriptor> = {
   [userValidationDescriptor.schema]: userValidationDescriptor,
+  [mobileValidationDescriptor.schema]: mobileValidationDescriptor,
+  [themeConfigDescriptor.schema]: themeConfigDescriptor,
+  [tenantBoundaryDescriptor.schema]: tenantBoundaryDescriptor,
+  [autoEscalationIgnoreDescriptor.schema]: autoEscalationIgnoreDescriptor,
+  [workflowBsMasterDescriptor.schema]: workflowBsMasterDescriptor,
+  [pgrUiConstantsDescriptor.schema]: pgrUiConstantsDescriptor,
 };
 
 export function getDescriptor(schemaCode?: string): SchemaDescriptor | undefined {

--- a/src/admin/schemaDescriptors/mobile-validation.ts
+++ b/src/admin/schemaDescriptors/mobile-validation.ts
@@ -1,0 +1,54 @@
+import type { SchemaDescriptor } from './types';
+
+/**
+ * Descriptor for `ValidationConfigs.mobileNumberValidation` — the mobile regex
+ * rules consumed by the `useMobileValidation` hook in DIGIT-UI (e.g. the Kenya
+ * default keyed "defaultMobileValidation" with pattern `^[17][0-9]{8}$`,
+ * prefix +254).
+ *
+ * This is the *sister* schema of `common-masters.UserValidation` (see
+ * `user-validation.ts`). The two overlap: both describe the same underlying
+ * format rules, but DIGIT runtime reads them from different MDMS locations.
+ * Editing one does NOT currently auto-propagate to the other — flagship
+ * `UserValidationEditor` (Stage 3) will write both atomically.
+ *
+ * The JSON Schema declares `rules` as a nested object, which the default
+ * auto-form would skip entirely. This descriptor expands nested paths into
+ * individual widgets.
+ */
+export const mobileValidationDescriptor: SchemaDescriptor = {
+  schema: 'ValidationConfigs.mobileNumberValidation',
+  groups: [
+    { title: 'Identity', fields: ['validationName'] },
+    { title: 'Format rules', fields: [
+      'rules.prefix',
+      'rules.pattern',
+      'rules.minLength',
+      'rules.maxLength',
+      'rules.allowedStartingDigits',
+      'rules.errorMessage',
+      'rules.isActive',
+    ] },
+  ],
+  fields: [
+    { path: 'validationName', widget: 'text', required: true,
+      help: 'Unique name for this validation rule — becomes the record\'s unique identifier (e.g. "defaultMobileValidation").' },
+    { path: 'rules.prefix', widget: 'text', label: 'Dial code prefix',
+      help: 'Country dial code shown/stored with the value, e.g. +254 (Kenya) or +91 (India).' },
+    { path: 'rules.pattern', widget: 'regex', label: 'Regex pattern',
+      help: 'The validation regex — use the sample box below to test.' },
+    { path: 'rules.minLength', widget: 'integer', min: 1, max: 20,
+      label: 'Min length',
+      help: 'Usually equal to Max length — most country mobile formats are fixed-length (e.g. 9 digits for KE, 10 for IN).' },
+    { path: 'rules.maxLength', widget: 'integer', min: 1, max: 20,
+      label: 'Max length',
+      help: 'Usually equal to Min length — most country mobile formats are fixed-length (e.g. 9 digits for KE, 10 for IN).' },
+    { path: 'rules.allowedStartingDigits', widget: 'chip-array',
+      label: 'Allowed starting digits',
+      help: 'First digit each mobile number must start with. For KE: 1, 7. For IN: 6, 7, 8, 9.' },
+    { path: 'rules.errorMessage', widget: 'text', label: 'Error message',
+      help: 'Literal message shown inline in DIGIT-UI on validation failure. Not a localization key — the exact text entered here is displayed to the user.' },
+    { path: 'rules.isActive', widget: 'boolean', label: 'Is active',
+      help: 'Whether this validation rule is currently active.' },
+  ],
+};

--- a/src/admin/schemaDescriptors/pgr-ui-constants.ts
+++ b/src/admin/schemaDescriptors/pgr-ui-constants.ts
@@ -1,0 +1,28 @@
+// Schema is `additionalProperties: false` so this descriptor stays tight — every future field must be declared explicitly.
+
+import type { SchemaDescriptor } from './types';
+
+/**
+ * Descriptor for `RAINMAKER-PGR.UIConstants` — PGR UI-facing constants.
+ *
+ * Currently holds a single knob, `REOPENSLA`: the millisecond window during
+ * which a citizen can reopen a resolved complaint. Live default is 432000000
+ * (5 days).
+ */
+export const pgrUiConstantsDescriptor: SchemaDescriptor = {
+  schema: 'RAINMAKER-PGR.UIConstants',
+  groups: [
+    { title: 'Constants', fields: ['REOPENSLA'] },
+  ],
+  fields: [
+    {
+      path: 'REOPENSLA',
+      widget: 'duration-ms',
+      required: true,
+      min: 60000,
+      max: 2592000000,
+      label: 'Reopen window (ms)',
+      help: 'How long after a complaint is resolved a citizen can still reopen it. Stored as milliseconds. Current default is 5 days (432000000).',
+    },
+  ],
+};

--- a/src/admin/schemaDescriptors/tenant-boundary.ts
+++ b/src/admin/schemaDescriptors/tenant-boundary.ts
@@ -1,0 +1,27 @@
+import type { SchemaDescriptor } from './types';
+
+/**
+ * Descriptor for `egov-location.TenantBoundary` — the legacy v1 boundary tree
+ * consumed by HRMS's jurisdiction picker (hierarchyType: ADMIN, etc.).
+ *
+ * The `boundary` tree field is intentionally not exposed — editing it requires
+ * a dedicated TreeEditor widget (deferred to Stage 3). The generic form's
+ * fallback already skips unknown object fields, which is the correct behavior
+ * here: we never want a text-dump of a deeply-nested County → SubCounty → Ward
+ * tree in a plain input. Only the flat scalars on `hierarchyType` are editable
+ * via this descriptor; the `boundary` subtree round-trips untouched.
+ */
+export const tenantBoundaryDescriptor: SchemaDescriptor = {
+  schema: 'egov-location.TenantBoundary',
+  groups: [
+    { title: 'Identity', fields: ['hierarchyType.code', 'hierarchyType.name'] },
+  ],
+  fields: [
+    { path: 'hierarchyType.code', widget: 'text', required: true,
+      label: 'Hierarchy code',
+      help: 'Unique identifier for the hierarchy (e.g. "ADMIN"). Used as the record\'s idField.' },
+    { path: 'hierarchyType.name', widget: 'text', required: true,
+      label: 'Hierarchy name',
+      help: 'Human-readable label for the hierarchy. Typically matches the code.' },
+  ],
+};

--- a/src/admin/schemaDescriptors/theme-config.ts
+++ b/src/admin/schemaDescriptors/theme-config.ts
@@ -1,0 +1,166 @@
+import type { SchemaDescriptor } from './types';
+
+/**
+ * Descriptor for `common-masters.ThemeConfig` — the per-tenant UI color palette
+ * (e.g. the "kenya-green" record driving Nairobi's green/red DIGIT theme).
+ *
+ * The JSON Schema declares `colors` as an untyped `type: "object"`, so the
+ * default auto-form would skip it entirely. The live records, however, carry
+ * a deep tree of named color tokens (primary, link, text, grey, alerts,
+ * digitv2 chart/alert tokens, etc). This descriptor expands every leaf color
+ * into its own `color` widget addressed by a dot path (e.g. `colors.primary.main`).
+ *
+ * Parent objects (`colors`, `colors.primary`, ...) are intentionally NOT listed
+ * as fields — the generic fallback skips them, which is what we want. Only the
+ * string-valued leaves are editable.
+ */
+export const themeConfigDescriptor: SchemaDescriptor = {
+  schema: 'common-masters.ThemeConfig',
+  groups: [
+    { title: 'Identity', fields: ['code', 'name', 'version'] },
+    { title: 'Primary / Link', fields: [
+      'colors.primary.main',
+      'colors.primary.dark',
+      'colors.primary.light',
+      'colors.primary.accent',
+      'colors.primary.selected-bg',
+      'colors.link.normal',
+      'colors.link.hover',
+      'colors.secondary',
+      'colors.border',
+      'colors.input-border',
+    ] },
+    { title: 'Text', fields: [
+      'colors.text.primary',
+      'colors.text.secondary',
+      'colors.text.heading',
+      'colors.text.muted',
+    ] },
+    { title: 'Grey', fields: [
+      'colors.grey.light',
+      'colors.grey.lighter',
+      'colors.grey.bg',
+      'colors.grey.mid',
+      'colors.grey.dark',
+      'colors.grey.disabled',
+    ] },
+    { title: 'Alerts & Status', fields: [
+      'colors.success',
+      'colors.error',
+      'colors.error-dark',
+      'colors.info-dark',
+      'colors.warning-dark',
+    ] },
+    { title: 'Charts', fields: [
+      'colors.digitv2.chart-1',
+      'colors.digitv2.chart-2',
+      'colors.digitv2.chart-3',
+      'colors.digitv2.chart-4',
+      'colors.digitv2.chart-5',
+    ] },
+    { title: 'DigitV2 tokens', fields: [
+      'colors.digitv2.primary-bg',
+      'colors.digitv2.header-sidenav',
+      'colors.digitv2.alert-info',
+      'colors.digitv2.alert-info-bg',
+      'colors.digitv2.alert-error-bg',
+      'colors.digitv2.alert-success-bg',
+      'colors.digitv2.text-color-disabled',
+    ] },
+  ],
+  fields: [
+    // --- Identity ---
+    { path: 'code', widget: 'text', required: true,
+      help: 'Unique theme identifier, e.g. "kenya-green". Used as the MDMS record key.' },
+    { path: 'name', widget: 'text',
+      help: 'Human-readable theme name shown in admin UIs.' },
+    { path: 'version', widget: 'text',
+      help: 'Optional version string, e.g. "1.0.0". Bump when shipping breaking token changes.' },
+
+    // --- Primary / Link ---
+    { path: 'colors.primary.main', widget: 'color', label: 'Primary / main',
+      help: 'The brand color — buttons, highlights, active nav.' },
+    { path: 'colors.primary.dark', widget: 'color', label: 'Primary / dark',
+      help: 'Darker shade of primary, used for hover / pressed states.' },
+    { path: 'colors.primary.light', widget: 'color', label: 'Primary / light',
+      help: 'Lighter shade of primary, used for soft backgrounds.' },
+    { path: 'colors.primary.accent', widget: 'color', label: 'Primary / accent',
+      help: 'Secondary accent color paired with primary (e.g. the red in kenya-green).' },
+    { path: 'colors.primary.selected-bg', widget: 'color', label: 'Primary / selected-bg',
+      help: 'Background tint for selected rows / active menu items.' },
+    { path: 'colors.link.normal', widget: 'color', label: 'Link / normal',
+      help: 'Default anchor color.' },
+    { path: 'colors.link.hover', widget: 'color', label: 'Link / hover',
+      help: 'Anchor color on hover / focus.' },
+    { path: 'colors.secondary', widget: 'color',
+      help: 'Secondary brand color, typically used for headings / dark UI.' },
+    { path: 'colors.border', widget: 'color',
+      help: '1px divider color, e.g. between rows in a table.' },
+    { path: 'colors.input-border', widget: 'color',
+      help: 'Border color for form inputs in their default (unfocused) state.' },
+
+    // --- Text ---
+    { path: 'colors.text.primary', widget: 'color', label: 'Text / primary',
+      help: 'Main body text color.' },
+    { path: 'colors.text.secondary', widget: 'color', label: 'Text / secondary',
+      help: 'De-emphasized text (captions, metadata).' },
+    { path: 'colors.text.heading', widget: 'color', label: 'Text / heading',
+      help: 'Color for h1–h6 headings.' },
+    { path: 'colors.text.muted', widget: 'color', label: 'Text / muted',
+      help: 'Faintest text — placeholders, disabled labels.' },
+
+    // --- Grey scale ---
+    { path: 'colors.grey.light', widget: 'color', label: 'Grey / light',
+      help: 'Lightest grey — page background.' },
+    { path: 'colors.grey.lighter', widget: 'color', label: 'Grey / lighter',
+      help: 'Slightly darker than `light`; section dividers / zebra rows.' },
+    { path: 'colors.grey.bg', widget: 'color', label: 'Grey / bg',
+      help: 'Neutral card / panel background.' },
+    { path: 'colors.grey.mid', widget: 'color', label: 'Grey / mid',
+      help: 'Mid grey for subtle borders / rule lines.' },
+    { path: 'colors.grey.dark', widget: 'color', label: 'Grey / dark',
+      help: 'Darker grey for icons and secondary chrome.' },
+    { path: 'colors.grey.disabled', widget: 'color', label: 'Grey / disabled',
+      help: 'Fill color for disabled buttons and inputs.' },
+
+    // --- Alerts & Status ---
+    { path: 'colors.success', widget: 'color',
+      help: 'Success / positive state (checkmarks, success toasts).' },
+    { path: 'colors.error', widget: 'color',
+      help: 'Error / destructive state (validation errors, delete buttons).' },
+    { path: 'colors.error-dark', widget: 'color',
+      help: 'Darker error shade — hover state for error buttons / text.' },
+    { path: 'colors.info-dark', widget: 'color',
+      help: 'Darker info shade — used on info text over light backgrounds.' },
+    { path: 'colors.warning-dark', widget: 'color',
+      help: 'Darker warning shade — used on warning text over light backgrounds.' },
+
+    // --- Charts (digitv2) ---
+    { path: 'colors.digitv2.chart-1', widget: 'color', label: 'DigitV2 / chart-1',
+      help: 'First series color in charts (bars, lines, pie slice 1).' },
+    { path: 'colors.digitv2.chart-2', widget: 'color', label: 'DigitV2 / chart-2',
+      help: 'Second chart series color.' },
+    { path: 'colors.digitv2.chart-3', widget: 'color', label: 'DigitV2 / chart-3',
+      help: 'Third chart series color.' },
+    { path: 'colors.digitv2.chart-4', widget: 'color', label: 'DigitV2 / chart-4',
+      help: 'Fourth chart series color.' },
+    { path: 'colors.digitv2.chart-5', widget: 'color', label: 'DigitV2 / chart-5',
+      help: 'Fifth chart series color.' },
+
+    // --- DigitV2 UI tokens ---
+    { path: 'colors.digitv2.primary-bg', widget: 'color', label: 'DigitV2 / primary-bg',
+      help: 'Tinted background paired with primary — e.g. selected-card fill.' },
+    { path: 'colors.digitv2.header-sidenav', widget: 'color', label: 'DigitV2 / header-sidenav',
+      help: 'Background color for the top header and side navigation rail.' },
+    { path: 'colors.digitv2.alert-info', widget: 'color', label: 'DigitV2 / alert-info',
+      help: 'Info alert accent / icon color.' },
+    { path: 'colors.digitv2.alert-info-bg', widget: 'color', label: 'DigitV2 / alert-info-bg',
+      help: 'Info alert background fill.' },
+    { path: 'colors.digitv2.alert-error-bg', widget: 'color', label: 'DigitV2 / alert-error-bg',
+      help: 'Error alert background fill.' },
+    { path: 'colors.digitv2.alert-success-bg', widget: 'color', label: 'DigitV2 / alert-success-bg',
+      help: 'Success alert background fill.' },
+    { path: 'colors.digitv2.text-color-disabled', widget: 'color', label: 'DigitV2 / text-color-disabled',
+      help: 'Text color used on disabled controls in the DigitV2 component set.' },
+  ],
+};

--- a/src/admin/schemaDescriptors/types.ts
+++ b/src/admin/schemaDescriptors/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Schema descriptor: per-schema config telling the generic Edit/Create form
+ * how to render fields the JSON Schema alone can't express richly (e.g. colors,
+ * regex testers, chip arrays, nested object paths).
+ *
+ * Without a descriptor, forms fall back to JSON-Schema-driven rendering and
+ * silently skip object/array fields. Adding a descriptor is additive and
+ * cannot break existing forms — missing fields just use defaults.
+ */
+
+export type WidgetKind =
+  | 'text'        // default; plain string input
+  | 'textarea'    // multi-line string
+  | 'integer'     // number input, step 1
+  | 'number'      // number input, any
+  | 'boolean'    // checkbox
+  | 'color'      // hex input + swatch preview
+  | 'regex'      // pattern field + live sample tester
+  | 'chip-array' // string[] editor (add on Enter, remove on x)
+  | 'duration-ms'; // number input alongside d/h/m/s display
+
+/** A single field override. `path` is dot-notation into the record (e.g. "rules.pattern"). */
+export interface FieldSpec {
+  path: string;
+  label?: string;
+  help?: string;
+  widget?: WidgetKind;
+  required?: boolean;
+  /** Hide this field in create / edit / always. */
+  hidden?: 'create' | 'edit' | 'always';
+  /** For integer/number widgets. */
+  min?: number;
+  max?: number;
+  /** For text/regex widgets — a static pattern to also enforce client-side. */
+  pattern?: string;
+}
+
+/** A grouping of fields shown as a titled section in the form. */
+export interface FieldGroup {
+  title: string;
+  /** Field paths in render order. Paths not listed in any group fall into an
+   *  unnamed "Other" section after all named groups. */
+  fields: string[];
+}
+
+export interface SchemaDescriptor {
+  schema: string;
+  groups?: FieldGroup[];
+  fields: FieldSpec[];
+}

--- a/src/admin/schemaDescriptors/user-validation.ts
+++ b/src/admin/schemaDescriptors/user-validation.ts
@@ -1,0 +1,49 @@
+import type { SchemaDescriptor } from './types';
+
+/**
+ * Descriptor for `common-masters.UserValidation` (e.g. the Kenya mobile rule
+ * keyed "mobile" with pattern `^0?[17][0-9]{8}$`, prefix +254).
+ *
+ * The JSON Schema declares `rules` and `attributes` as nested objects, so the
+ * default auto-form would skip them entirely. This descriptor expands nested
+ * paths into individual widgets.
+ *
+ * Note: DIGIT runtime also reads `ValidationConfigs.mobileNumberValidation`
+ * via `useMobileValidation`. The two schemas overlap; for now editing one
+ * does NOT auto-propagate to the other. Flagship `UserValidationEditor`
+ * (Stage 3) will write both atomically.
+ */
+export const userValidationDescriptor: SchemaDescriptor = {
+  schema: 'common-masters.UserValidation',
+  groups: [
+    { title: 'Field', fields: ['fieldType', 'default', 'isActive'] },
+    { title: 'Format rules', fields: [
+      'attributes.prefix',
+      'rules.pattern',
+      'rules.minLength',
+      'rules.maxLength',
+      'rules.allowedStartingCharacters',
+      'rules.errorMessage',
+    ] },
+  ],
+  fields: [
+    { path: 'fieldType', widget: 'text', required: true,
+      help: 'e.g. "mobile", "email". Becomes the record\'s unique identifier.' },
+    { path: 'default', widget: 'boolean',
+      help: 'Mark this rule as the default for its fieldType.' },
+    { path: 'isActive', widget: 'boolean' },
+    { path: 'attributes.prefix', widget: 'text', label: 'Dial code prefix',
+      help: 'Country prefix shown/stored with the value (e.g. +254 for Kenya).' },
+    { path: 'rules.pattern', widget: 'regex', label: 'Regex pattern',
+      help: 'The validation regex — use the sample box below to test.' },
+    { path: 'rules.minLength', widget: 'integer', min: 1, max: 30,
+      label: 'Min length' },
+    { path: 'rules.maxLength', widget: 'integer', min: 1, max: 30,
+      label: 'Max length' },
+    { path: 'rules.allowedStartingCharacters', widget: 'chip-array',
+      label: 'Allowed first characters',
+      help: 'First digit/char each value must start with. For KE mobile: 0, 1, 7.' },
+    { path: 'rules.errorMessage', widget: 'text', label: 'Error message key',
+      help: 'Localization key shown on validation failure, e.g. CORE_COMMON_MOBILE_ERROR.' },
+  ],
+};

--- a/src/admin/schemaDescriptors/workflow-bs-master.ts
+++ b/src/admin/schemaDescriptors/workflow-bs-master.ts
@@ -1,0 +1,32 @@
+/**
+ * Descriptor for `Workflow.BusinessServiceMasterConfig` — a state-level override
+ * controlling whether a workflow business service (e.g. "Incident", "NewTL") is
+ * managed state-wide or per-tenant.
+ *
+ * NOTE on string-typed booleans:
+ * Both `isStatelevel` and `active` are typed as `string` in the schema but
+ * store the literal text 'true' / 'false'. UI does not boolean-coerce — it
+ * preserves whatever the user types. Consider a dedicated string-bool widget
+ * in Stage 3.
+ *
+ * NOTE on unique identifier:
+ * Live records use `active` as the unique identifier (observed value: "true"),
+ * which collapses the whole master to a single row per state. This looks like
+ * an upstream config bug — flagged for Stage 4 QA, preserved as-is here.
+ */
+import type { SchemaDescriptor } from './types';
+
+export const workflowBsMasterDescriptor: SchemaDescriptor = {
+  schema: 'Workflow.BusinessServiceMasterConfig',
+  groups: [
+    { title: 'Config', fields: ['businessService', 'isStatelevel', 'active'] },
+  ],
+  fields: [
+    { path: 'businessService', widget: 'text', required: true,
+      help: 'Workflow business service code, e.g. Incident, NewTL.' },
+    { path: 'isStatelevel', widget: 'text', required: true,
+      help: "String-typed bool: 'true' or 'false'. Controls whether this BS is shared across all tenants." },
+    { path: 'active', widget: 'text', required: true,
+      help: "String-typed bool: 'true' or 'false'. Also used as the record's unique identifier — upstream quirk." },
+  ],
+};

--- a/src/admin/widgets/BooleanInput.tsx
+++ b/src/admin/widgets/BooleanInput.tsx
@@ -1,0 +1,38 @@
+import { useInput, type InputProps } from 'ra-core';
+import { Label } from '@/components/ui/label';
+
+interface BooleanInputProps extends InputProps {
+  label?: string;
+  help?: string;
+}
+
+/** Checkbox bound to a real boolean form value. Unlike a text-fallback, this
+ *  preserves the boolean type on round-trip — some MDMS schemas reject
+ *  string-"true" where a JSON bool is expected. */
+export function BooleanInput({ label, help, ...inputProps }: BooleanInputProps) {
+  const { id, field, isRequired } = useInput({
+    ...inputProps,
+    parse: (v: boolean) => v,
+  });
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        <input
+          id={id}
+          type="checkbox"
+          checked={!!field.value}
+          onChange={(e) => field.onChange(e.target.checked)}
+          onBlur={field.onBlur}
+          className="h-4 w-4 rounded border-input cursor-pointer"
+        />
+        {label && (
+          <Label htmlFor={id} className="text-sm font-medium text-foreground">
+            {label}
+            {isRequired && <span className="text-destructive ml-0.5">*</span>}
+          </Label>
+        )}
+      </div>
+      {help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/src/admin/widgets/ChipArrayInput.tsx
+++ b/src/admin/widgets/ChipArrayInput.tsx
@@ -1,0 +1,77 @@
+import { useState, type KeyboardEvent } from 'react';
+import { useInput, type InputProps } from 'ra-core';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { X } from 'lucide-react';
+
+interface ChipArrayInputProps extends InputProps {
+  label?: string;
+  help?: string;
+}
+
+/** string[] editor: add on Enter/comma, remove via × button. Form value is
+ *  the string array; drafts live in local state until committed. */
+export function ChipArrayInput({ label, help, ...inputProps }: ChipArrayInputProps) {
+  const { id, field, isRequired } = useInput(inputProps);
+  const [draft, setDraft] = useState('');
+  const value: string[] = Array.isArray(field.value) ? field.value : [];
+
+  const commit = () => {
+    const next = draft.trim();
+    if (!next) return;
+    if (!value.includes(next)) field.onChange([...value, next]);
+    setDraft('');
+  };
+
+  const remove = (item: string) => {
+    field.onChange(value.filter((v) => v !== item));
+  };
+
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      commit();
+    } else if (e.key === 'Backspace' && !draft && value.length > 0) {
+      field.onChange(value.slice(0, -1));
+    }
+  };
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {isRequired && <span className="text-destructive ml-0.5">*</span>}
+        </Label>
+      )}
+      <div className="flex flex-wrap gap-1.5 mb-1.5">
+        {value.map((item) => (
+          <span
+            key={item}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-primary/10 text-primary text-xs font-medium"
+          >
+            {item}
+            <button
+              type="button"
+              onClick={() => remove(item)}
+              aria-label={`remove ${item}`}
+              className="hover:text-destructive"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+      <Input
+        id={id}
+        type="text"
+        placeholder="type and press Enter"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={handleKey}
+        onBlur={() => { if (draft.trim()) commit(); field.onBlur(); }}
+      />
+      {help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/src/admin/widgets/ColorInput.tsx
+++ b/src/admin/widgets/ColorInput.tsx
@@ -1,0 +1,59 @@
+import { useInput, type InputProps } from 'ra-core';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const HEX_PATTERN = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+interface ColorInputProps extends InputProps {
+  label?: string;
+  help?: string;
+}
+
+/** Minimal hex color input: native color picker + hex text box + live swatch.
+ *  Keeps the form value as a hex string (e.g. "#006B3F"). Falls back to plain
+ *  text editing if the value is not a valid hex. */
+export function ColorInput({ label, help, ...inputProps }: ColorInputProps) {
+  const { id, field, fieldState, isRequired } = useInput(inputProps);
+  const hasError = fieldState.invalid && fieldState.isTouched;
+  const value = typeof field.value === 'string' ? field.value : '';
+  const isValidHex = HEX_PATTERN.test(value);
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {isRequired && <span className="text-destructive ml-0.5">*</span>}
+        </Label>
+      )}
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          aria-label={`${label ?? 'color'} picker`}
+          value={isValidHex && value.length === 7 ? value : '#000000'}
+          onChange={(e) => field.onChange(e.target.value)}
+          className="h-9 w-9 rounded border border-input cursor-pointer bg-transparent p-0.5"
+        />
+        <Input
+          id={id}
+          type="text"
+          placeholder="#RRGGBB"
+          value={value}
+          onChange={(e) => field.onChange(e.target.value)}
+          onBlur={field.onBlur}
+          className={`font-mono ${hasError ? 'border-destructive' : ''}`}
+        />
+        <div
+          aria-hidden
+          className="h-9 w-9 rounded border border-input shrink-0"
+          style={{ backgroundColor: isValidHex ? value : 'transparent' }}
+          title={isValidHex ? value : 'invalid hex'}
+        />
+      </div>
+      {help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+      {!isValidHex && value.length > 0 && (
+        <p className="mt-1 text-xs text-destructive">Not a valid hex color (#RGB / #RRGGBB / #RRGGBBAA)</p>
+      )}
+    </div>
+  );
+}

--- a/src/admin/widgets/DurationMsInput.tsx
+++ b/src/admin/widgets/DurationMsInput.tsx
@@ -1,0 +1,60 @@
+import { useInput, type InputProps } from 'ra-core';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface DurationMsInputProps extends InputProps {
+  label?: string;
+  help?: string;
+  min?: number;
+  max?: number;
+}
+
+function formatMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '0s';
+  const d = Math.floor(ms / 86_400_000);
+  const h = Math.floor((ms % 86_400_000) / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  const s = Math.floor((ms % 60_000) / 1000);
+  const parts = [];
+  if (d) parts.push(`${d}d`);
+  if (h) parts.push(`${h}h`);
+  if (m) parts.push(`${m}m`);
+  if (s) parts.push(`${s}s`);
+  return parts.join(' ') || '0s';
+}
+
+/** Number input for a millisecond duration with a human-readable label
+ *  ("5d 3h 2m") underneath. Keeps the stored value as an integer ms count. */
+export function DurationMsInput({ label, help, min, max, ...inputProps }: DurationMsInputProps) {
+  const { id, field, fieldState, isRequired } = useInput({
+    ...inputProps,
+    parse: (v: string) => (v === '' ? null : Number(v)),
+  });
+  const hasError = fieldState.invalid && fieldState.isTouched;
+  const ms = typeof field.value === 'number' ? field.value : Number(field.value);
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {isRequired && <span className="text-destructive ml-0.5">*</span>}
+        </Label>
+      )}
+      <Input
+        id={id}
+        type="number"
+        min={min}
+        max={max}
+        placeholder="milliseconds"
+        {...field}
+        value={field.value ?? ''}
+        className={`font-mono ${hasError ? 'border-destructive' : ''}`}
+      />
+      <p className="mt-1 text-xs text-muted-foreground">
+        <span className="font-medium">{formatMs(ms)}</span>
+        {help && <> — {help}</>}
+      </p>
+    </div>
+  );
+}

--- a/src/admin/widgets/RegexInput.tsx
+++ b/src/admin/widgets/RegexInput.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useInput, type InputProps } from 'ra-core';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Check, X } from 'lucide-react';
+
+interface RegexInputProps extends InputProps {
+  label?: string;
+  help?: string;
+}
+
+/** Regex pattern field with a live sample tester below it.
+ *  Form value is the pattern string. Sample text is local-only (not persisted). */
+export function RegexInput({ label, help, ...inputProps }: RegexInputProps) {
+  const { id, field, fieldState, isRequired } = useInput(inputProps);
+  const [sample, setSample] = useState('');
+  const pattern = typeof field.value === 'string' ? field.value : '';
+
+  let regex: RegExp | null = null;
+  let compileError: string | null = null;
+  try {
+    regex = pattern ? new RegExp(pattern) : null;
+  } catch (e) {
+    compileError = e instanceof Error ? e.message : 'invalid regex';
+  }
+  const matches = regex && sample ? regex.test(sample) : null;
+  const hasError = fieldState.invalid && fieldState.isTouched;
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {isRequired && <span className="text-destructive ml-0.5">*</span>}
+        </Label>
+      )}
+      <Input
+        id={id}
+        type="text"
+        placeholder="^[0-9]{10}$"
+        value={pattern}
+        onChange={(e) => field.onChange(e.target.value)}
+        onBlur={field.onBlur}
+        className={`font-mono ${hasError || compileError ? 'border-destructive' : ''}`}
+      />
+      {help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+      {compileError && <p className="mt-1 text-xs text-destructive">Regex error: {compileError}</p>}
+      <div className="mt-2 flex items-center gap-2">
+        <Input
+          type="text"
+          placeholder="test a sample..."
+          value={sample}
+          onChange={(e) => setSample(e.target.value)}
+          className="flex-1"
+          aria-label="sample text to test against pattern"
+        />
+        {matches === true && <Check className="w-4 h-4 text-success" aria-label="matches" />}
+        {matches === false && <X className="w-4 h-4 text-destructive" aria-label="does not match" />}
+      </div>
+    </div>
+  );
+}

--- a/src/admin/widgets/index.tsx
+++ b/src/admin/widgets/index.tsx
@@ -1,0 +1,43 @@
+import { DigitFormInput } from '../DigitFormInput';
+import { ColorInput } from './ColorInput';
+import { RegexInput } from './RegexInput';
+import { ChipArrayInput } from './ChipArrayInput';
+import { DurationMsInput } from './DurationMsInput';
+import type { FieldSpec } from '../schemaDescriptors/types';
+
+interface WidgetDispatchProps {
+  spec: FieldSpec;
+  source: string;
+}
+
+/** Pick a widget based on spec.widget. Falls back to a plain text input for
+ *  anything unrecognized — the user asked for this explicitly: "drop any to
+ *  simpler versions (only text edit maybe) that aren't working out."
+ *  The source path is used as-is; react-hook-form natively traverses "a.b.c". */
+export function WidgetForFieldSpec({ spec, source }: WidgetDispatchProps) {
+  const label = spec.label ?? source;
+  const shared = { source, label };
+
+  switch (spec.widget) {
+    case 'color':
+      return <ColorInput {...shared} help={spec.help} />;
+    case 'regex':
+      return <RegexInput {...shared} help={spec.help} />;
+    case 'chip-array':
+      return <ChipArrayInput {...shared} help={spec.help} />;
+    case 'duration-ms':
+      return <DurationMsInput {...shared} help={spec.help} min={spec.min} max={spec.max} />;
+    case 'integer':
+    case 'number':
+      return <DigitFormInput {...shared} type="number" />;
+    case 'textarea':
+      // No dedicated textarea component yet; fall back to plain text. TODO.
+      return <DigitFormInput {...shared} type="text" />;
+    case 'boolean':
+    case 'text':
+    default:
+      return <DigitFormInput {...shared} type="text" />;
+  }
+}
+
+export { ColorInput, RegexInput, ChipArrayInput, DurationMsInput };

--- a/src/admin/widgets/index.tsx
+++ b/src/admin/widgets/index.tsx
@@ -3,6 +3,7 @@ import { ColorInput } from './ColorInput';
 import { RegexInput } from './RegexInput';
 import { ChipArrayInput } from './ChipArrayInput';
 import { DurationMsInput } from './DurationMsInput';
+import { BooleanInput } from './BooleanInput';
 import type { FieldSpec } from '../schemaDescriptors/types';
 
 interface WidgetDispatchProps {
@@ -27,17 +28,18 @@ export function WidgetForFieldSpec({ spec, source }: WidgetDispatchProps) {
       return <ChipArrayInput {...shared} help={spec.help} />;
     case 'duration-ms':
       return <DurationMsInput {...shared} help={spec.help} min={spec.min} max={spec.max} />;
+    case 'boolean':
+      return <BooleanInput {...shared} help={spec.help} />;
     case 'integer':
     case 'number':
-      return <DigitFormInput {...shared} type="number" />;
+      return <DigitFormInput {...shared} type="number" help={spec.help} />;
     case 'textarea':
       // No dedicated textarea component yet; fall back to plain text. TODO.
-      return <DigitFormInput {...shared} type="text" />;
-    case 'boolean':
+      return <DigitFormInput {...shared} type="text" help={spec.help} />;
     case 'text':
     default:
-      return <DigitFormInput {...shared} type="text" />;
+      return <DigitFormInput {...shared} type="text" help={spec.help} />;
   }
 }
 
-export { ColorInput, RegexInput, ChipArrayInput, DurationMsInput };
+export { ColorInput, RegexInput, ChipArrayInput, DurationMsInput, BooleanInput };

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -23,6 +23,7 @@ export const ENDPOINTS = {
   BOUNDARY_HIERARCHY_CREATE: '/boundary-service/boundary-hierarchy-definition/_create',
   BOUNDARY_CREATE: '/boundary-service/boundary/_create',
   BOUNDARY_RELATIONSHIP_CREATE: '/boundary-service/boundary-relationships/_create',
+  BOUNDARY_RELATIONSHIP_SEARCH: '/boundary-service/boundary-relationships/_search',
 
   // HRMS
   HRMS_EMPLOYEES_SEARCH: '/egov-hrms/employees/_search',

--- a/src/api/services/boundary.ts
+++ b/src/api/services/boundary.ts
@@ -23,7 +23,15 @@ export const boundaryService = {
     return hierarchies as BoundaryHierarchy[];
   },
 
-  // Create a new boundary hierarchy
+  // Create a new boundary hierarchy.
+  //
+  // Backend quirk: the create endpoint sends a single-object request
+  // but responds with BoundaryHierarchy as an ARRAY (the search
+  // endpoint uses the same response shape, which is also an array).
+  // Casting the array directly to a single BoundaryHierarchy at the
+  // type level silently succeeds — TS has no idea the shape is wrong
+  // at runtime — and the caller ends up holding an object where
+  // `.hierarchyType` is undefined.
   async createHierarchy(
     tenantId: string,
     hierarchyType: string,
@@ -38,7 +46,9 @@ export const boundaryService = {
       },
     });
 
-    return response.BoundaryHierarchy as BoundaryHierarchy;
+    const raw = response.BoundaryHierarchy;
+    if (Array.isArray(raw)) return raw[0] as BoundaryHierarchy;
+    return raw as BoundaryHierarchy;
   },
 
   // Helper to create hierarchy from level names

--- a/src/api/services/boundary.ts
+++ b/src/api/services/boundary.ts
@@ -60,7 +60,14 @@ export const boundaryService = {
   // Boundary Methods
   // ============================================
 
-  // Search boundaries
+  // Search boundaries — returns the hierarchical tree flattened to a list.
+  //
+  // Uses /boundary-service/boundary-relationships/_search rather than
+  // /boundary-service/boundary/_search: the latter looks up boundary
+  // *entities* by code and does not return children, so asking it for
+  // "everything under tenant X" comes back with nothing even when the
+  // tree is fully seeded. The relationships endpoint walks the hierarchy
+  // and accepts filters via query-string params (not body).
   async searchBoundaries(
     tenantId: string,
     options?: {
@@ -71,46 +78,29 @@ export const boundaryService = {
       offset?: number;
     }
   ): Promise<Boundary[]> {
-    const response = await apiClient.post(ENDPOINTS.BOUNDARY_SEARCH, {
-      RequestInfo: apiClient.buildRequestInfo(),
-      Boundary: {
-        tenantId,
-        hierarchyType: options?.hierarchyType,
-        boundaryType: options?.boundaryType,
-        codes: options?.codes,
-        limit: options?.limit || 100,
-        offset: options?.offset || 0,
-      },
-    });
+    const qs = new URLSearchParams({ tenantId, includeChildren: 'true' });
+    if (options?.hierarchyType) qs.set('hierarchyType', options.hierarchyType);
+    if (options?.boundaryType)  qs.set('boundaryType',  options.boundaryType);
+    if (options?.codes?.length) qs.set('codes',         options.codes.join(','));
 
-    // Handle both response formats:
-    // - Old format: TenantBoundary[] with nested hierarchy
-    // - New format: Boundary[] flat array
+    const response = await apiClient.post(
+      `${ENDPOINTS.BOUNDARY_RELATIONSHIP_SEARCH}?${qs.toString()}`,
+      { RequestInfo: apiClient.buildRequestInfo() },
+    );
+
+    // Response shape: TenantBoundary[] where each block has a `boundary`
+    // field that may be either a single node or an array of roots. The
+    // relationships endpoint also sometimes duplicates children under
+    // their parent in the payload, so we dedupe by code as we flatten.
     const tenantBoundaries = response.TenantBoundary || [];
-    const flatBoundaries = response.Boundary || [];
     const boundaries: Boundary[] = [];
+    const seen = new Set<string>();
 
-    // Old format: flatten nested hierarchy
-    for (const tb of tenantBoundaries as { boundary: Boundary }[]) {
-      if (tb.boundary) {
-        this.flattenBoundaries(tb.boundary, boundaries);
-      }
-    }
-
-    // New format: flat boundary array
-    for (const b of flatBoundaries as Boundary[]) {
-      if (b.code) {
-        boundaries.push({
-          id: b.id,
-          tenantId: b.tenantId,
-          code: b.code,
-          name: b.name,
-          boundaryType: b.boundaryType,
-          parent: b.parent,
-          hierarchyType: b.hierarchyType,
-          latitude: b.latitude,
-          longitude: b.longitude,
-        });
+    for (const tb of tenantBoundaries as { boundary: Boundary | Boundary[]; hierarchyType?: string }[]) {
+      if (!tb.boundary) continue;
+      const items = Array.isArray(tb.boundary) ? tb.boundary : [tb.boundary];
+      for (const root of items) {
+        this.flattenBoundaries(root, boundaries, seen, tb.hierarchyType);
       }
     }
 
@@ -118,7 +108,21 @@ export const boundaryService = {
   },
 
   // Helper to flatten nested boundary tree
-  flattenBoundaries(boundary: Boundary, result: Boundary[]): void {
+  // Flatten a nested boundary tree into a flat list, deduping by code
+  // (the relationships endpoint duplicates children under their parent)
+  // and carrying hierarchyType down from the parent TenantBoundary wrapper
+  // when inner nodes don't have it set.
+  flattenBoundaries(
+    boundary: Boundary,
+    result: Boundary[],
+    seen?: Set<string>,
+    hierarchyType?: string,
+  ): void {
+    const code = boundary.code;
+    if (seen && code) {
+      if (seen.has(code)) return;
+      seen.add(code);
+    }
     result.push({
       id: boundary.id,
       tenantId: boundary.tenantId,
@@ -126,14 +130,14 @@ export const boundaryService = {
       name: boundary.name,
       boundaryType: boundary.boundaryType,
       parent: boundary.parent,
-      hierarchyType: boundary.hierarchyType,
+      hierarchyType: boundary.hierarchyType ?? hierarchyType,
       latitude: boundary.latitude,
       longitude: boundary.longitude,
     });
 
     if (boundary.children) {
       for (const child of boundary.children) {
-        this.flattenBoundaries(child, result);
+        this.flattenBoundaries(child, result, seen, hierarchyType);
       }
     }
   },

--- a/src/api/services/boundary.ts
+++ b/src/api/services/boundary.ts
@@ -142,7 +142,14 @@ export const boundaryService = {
     }
   },
 
-  // Create a boundary entity (just the entity, not the relationship)
+  // Create a boundary entity (just the entity, not the relationship).
+  // If the backend reports "already exists", verify the entity truly lives
+  // in the DB before swallowing — the boundary-service occasionally returns
+  // a false-positive "already exists" when a prior request is still sitting
+  // in its cache but the row never actually landed (also seen right after
+  // a direct DB cleanup, before the service's in-memory dedup cache times
+  // out). Blanket-swallowing that error made Phase 2 claim success while
+  // creating nothing.
   async createBoundaryEntity(tenantId: string, code: string): Promise<boolean> {
     try {
       await apiClient.post(ENDPOINTS.BOUNDARY_CREATE, {
@@ -155,16 +162,36 @@ export const boundaryService = {
       });
       return true;
     } catch (error) {
-      // Check if already exists (which is OK)
       const errorMsg = error instanceof Error ? error.message : String(error);
       if (errorMsg.toLowerCase().includes('already exists') || errorMsg.includes('DUPLICATE')) {
-        return true;
+        const found = await this.boundaryEntityExists(tenantId, code);
+        if (found) return true;
+        throw new Error(
+          `Backend reported boundary entity ${code} already exists, but a search returned nothing. ` +
+          `Retry may be needed, or a stale cache/Kafka state is masking the real error.`
+        );
       }
       throw error;
     }
   },
 
-  // Create a boundary relationship (parent-child link in hierarchy)
+  async boundaryEntityExists(tenantId: string, code: string): Promise<boolean> {
+    try {
+      const response = await apiClient.post(
+        `${ENDPOINTS.BOUNDARY_SEARCH}?tenantId=${encodeURIComponent(tenantId)}&codes=${encodeURIComponent(code)}`,
+        { RequestInfo: apiClient.buildRequestInfo() },
+      );
+      return (response.Boundary?.length ?? 0) > 0;
+    } catch {
+      return false;
+    }
+  },
+
+  // Create a boundary relationship (parent-child link in hierarchy).
+  // Same verify-before-swallow pattern as createBoundaryEntity — the
+  // backend sometimes returns "already exists" for relationships that
+  // never persisted. This was the root cause of Phase 2 silently
+  // reporting "4 boundaries created" with 0 relationships in the DB.
   async createBoundaryRelationship(
     tenantId: string,
     hierarchyType: string,
@@ -190,12 +217,30 @@ export const boundaryService = {
       await apiClient.post(ENDPOINTS.BOUNDARY_RELATIONSHIP_CREATE, payload);
       return true;
     } catch (error) {
-      // Check if already exists (which is OK)
       const errorMsg = error instanceof Error ? error.message : String(error);
       if (errorMsg.toLowerCase().includes('already exists') || errorMsg.includes('DUPLICATE')) {
-        return true;
+        const found = await this.boundaryRelationshipExists(tenantId, hierarchyType, code);
+        if (found) return true;
+        throw new Error(
+          `Backend reported relationship ${code} (${hierarchyType}) already exists, ` +
+          `but a search returned nothing. Likely a stale cache — try again in a few seconds ` +
+          `or clean up and re-run.`
+        );
       }
       throw error;
+    }
+  },
+
+  async boundaryRelationshipExists(tenantId: string, hierarchyType: string, code: string): Promise<boolean> {
+    try {
+      const qs = new URLSearchParams({ tenantId, hierarchyType, codes: code, includeChildren: 'false' });
+      const response = await apiClient.post(
+        `${ENDPOINTS.BOUNDARY_RELATIONSHIP_SEARCH}?${qs.toString()}`,
+        { RequestInfo: apiClient.buildRequestInfo() },
+      );
+      return (response.TenantBoundary?.length ?? 0) > 0;
+    } catch {
+      return false;
     }
   },
 

--- a/src/api/services/hrms.ts
+++ b/src/api/services/hrms.ts
@@ -145,7 +145,12 @@ export const hrmsService = {
       jurisdictions: data.jurisdictions.map((j) => ({
         boundary: j.boundary,
         boundaryType: j.boundaryType,
+        // HRMS DTO names this field `hierarchy`, not `hierarchyType` — the MDMS
+        // side uses `hierarchyType` elsewhere, so the naming is inconsistent
+        // across DIGIT. Send both so either spelling works.
+        hierarchy: j.hierarchyType,
         hierarchyType: j.hierarchyType,
+        tenantId: data.tenantId,
         isActive: true,
       })),
       assignments: [

--- a/src/api/services/hrms.ts
+++ b/src/api/services/hrms.ts
@@ -101,6 +101,7 @@ export const hrmsService = {
     mobileNumber: string;
     emailId?: string;
     gender?: string;
+    dob?: number;
     department: string;
     designation: string;
     roles: Role[];
@@ -109,6 +110,12 @@ export const hrmsService = {
     password?: string;
   }): Employee {
     const now = Date.now();
+    // HRMS validates user.dob with @NotNull. If the caller didn't provide
+    // one, fall back to 1990-01-01 UTC — otherwise the create fails the
+    // whole batch with NotNull.employeeRequest.employees[0].user.dob.
+    // TODO: surface DOB as a proper form field / Excel column so we're
+    // not silently defaulting real data.
+    const dob = data.dob ?? Date.UTC(1990, 0, 1);
 
     const user: EmployeeUser = {
       userName: data.userName.toLowerCase(),
@@ -117,6 +124,7 @@ export const hrmsService = {
       mobileNumber: data.mobileNumber,
       emailId: data.emailId,
       gender: data.gender,
+      dob,
       type: 'EMPLOYEE',
       active: true,
       tenantId: data.tenantId,

--- a/src/api/services/localization.ts
+++ b/src/api/services/localization.ts
@@ -115,19 +115,19 @@ export const localizationService = {
   buildComplaintTypeLocalizations(
     _tenantId: string,
     serviceCode: string,
-    serviceName: string,
+    name: string,
     locale: string = 'en_IN'
   ): LocalizationMessage[] {
     return [
       {
         code: `SERVICEDEFS.${serviceCode}`,
-        message: serviceName,
+        message: name,
         module: 'rainmaker-pgr',
         locale,
       },
       {
         code: `SERVICEDEFS.${serviceCode.toUpperCase()}`,
-        message: serviceName,
+        message: name,
         module: 'rainmaker-pgr',
         locale,
       },
@@ -201,11 +201,11 @@ export const localizationService = {
   // Upload localizations for all complaint types
   async uploadComplaintTypeLocalizations(
     tenantId: string,
-    types: { serviceCode: string; serviceName: string }[],
+    types: { serviceCode: string; name: string }[],
     locale: string = 'en_IN'
   ): Promise<{ success: number; failed: number }> {
     const messages = types.flatMap((t) =>
-      this.buildComplaintTypeLocalizations(tenantId, t.serviceCode, t.serviceName, locale)
+      this.buildComplaintTypeLocalizations(tenantId, t.serviceCode, t.name, locale)
     );
     return this.upsertMessages(tenantId, locale, messages);
   },

--- a/src/api/services/localization.ts
+++ b/src/api/services/localization.ts
@@ -111,27 +111,28 @@ export const localizationService = {
     ];
   },
 
-  // Create localization for a complaint type
+  // Create localization for a complaint type.
+  // We emit both the verbatim code and an uppercase variant for back-compat
+  // with consumers that lowercase/uppercase the serviceCode before lookup.
+  // Deduped so an already-uppercase serviceCode doesn't produce two identical
+  // rows — the backend's upsert rejects the whole batch on
+  // core.DUPLICATE_MESSAGE_IDENTITY when it sees the repeat.
   buildComplaintTypeLocalizations(
     _tenantId: string,
     serviceCode: string,
     name: string,
     locale: string = 'en_IN'
   ): LocalizationMessage[] {
-    return [
-      {
-        code: `SERVICEDEFS.${serviceCode}`,
-        message: name,
-        module: 'rainmaker-pgr',
-        locale,
-      },
-      {
-        code: `SERVICEDEFS.${serviceCode.toUpperCase()}`,
-        message: name,
-        module: 'rainmaker-pgr',
-        locale,
-      },
-    ];
+    const codes = new Set<string>([
+      `SERVICEDEFS.${serviceCode}`,
+      `SERVICEDEFS.${serviceCode.toUpperCase()}`,
+    ]);
+    return Array.from(codes).map((code) => ({
+      code,
+      message: name,
+      module: 'rainmaker-pgr',
+      locale,
+    }));
   },
 
   // Create localization for a boundary

--- a/src/api/services/mdms.ts
+++ b/src/api/services/mdms.ts
@@ -102,8 +102,8 @@ export const mdmsService = {
     return this.create(tenantId, MDMS_SCHEMAS.DESIGNATION, designation.code, {
       code: designation.code,
       name: designation.name,
-      description: designation.name,
-      department: designation.department ? [designation.department] : [],
+      description: designation.description,
+      department: designation.department,
       active: designation.active,
     });
   },

--- a/src/api/services/mdms.ts
+++ b/src/api/services/mdms.ts
@@ -142,7 +142,8 @@ export const mdmsService = {
 
     return results.map((r) => ({
       serviceCode: r.serviceCode as string,
-      serviceName: (r.serviceName || r.name) as string,
+      name: (r.name || r.serviceName) as string,
+      keywords: (r.keywords as string) || '',
       department: r.department as string,
       slaHours: r.slaHours as number,
       menuPath: r.menuPath as string | undefined,
@@ -161,8 +162,8 @@ export const mdmsService = {
       complaintType.serviceCode,
       {
         serviceCode: complaintType.serviceCode,
-        name: complaintType.serviceName,
-        keywords: complaintType.serviceName.toLowerCase(),
+        name: complaintType.name,
+        keywords: complaintType.keywords,
         department: complaintType.department,
         slaHours: complaintType.slaHours,
         menuPath: complaintType.menuPath || 'Complaint',

--- a/src/api/services/mdms.ts
+++ b/src/api/services/mdms.ts
@@ -217,11 +217,16 @@ export const mdmsService = {
   },
 
   async createTenant(stateTenantId: string, tenant: Tenant): Promise<MdmsRecord> {
-    // Build the full tenant data structure matching MDMS schema
+    // Build the full tenant data structure matching MDMS schema.
+    // tenant.tenants requires `tenantId` inside data (in addition to the
+    // Mdms.tenantId wrapper) — it stores the *parent* tenant this city lives
+    // under, e.g. for `ke.testzone` the parent is `ke`. Setting it to the
+    // tenant's own code (as the previous implementation did) is semantically
+    // wrong — MDMS inheritance relies on this being the parent.
     const tenantData = {
+      tenantId: stateTenantId,
       code: tenant.code,
       name: tenant.name,
-      tenantId: tenant.code,
       type: tenant.city?.ulbGrade || 'CITY',
       description: tenant.description || tenant.name,
       logoId: tenant.logoId || null,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -137,7 +137,8 @@ export interface Department {
 export interface Designation {
   code: string;
   name: string;
-  department?: string;
+  description: string;
+  department?: string[];
   active: boolean;
   tenantId?: string;
 }
@@ -370,7 +371,8 @@ export interface DepartmentExcelRow {
 export interface DesignationExcelRow {
   code: string;
   name: string;
-  department?: string;
+  description: string;
+  department?: string[];
   active: boolean;
 }
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -146,7 +146,8 @@ export interface Designation {
 // Complaint Type / Service Definition
 export interface ComplaintType {
   serviceCode: string;
-  serviceName: string;
+  name: string;
+  keywords: string;
   department: string;
   slaHours: number;
   menuPath?: string;
@@ -378,7 +379,8 @@ export interface DesignationExcelRow {
 
 export interface ComplaintTypeExcelRow {
   serviceCode: string;
-  serviceName: string;
+  name: string;
+  keywords: string;
   department: string;
   slaHours: number;
   active: boolean;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -393,6 +393,7 @@ export interface EmployeeExcelRow {
   mobileNumber: string;
   emailId?: string;
   gender?: string;
+  dob?: string;
   department: string;
   designation: string;
   roles: string; // comma-separated

--- a/src/pages/CompletePage.tsx
+++ b/src/pages/CompletePage.tsx
@@ -1,14 +1,74 @@
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../App';
-import { PartyPopper, Check, ExternalLink, RotateCcw, History, LogOut } from 'lucide-react';
+import { PartyPopper, Check, ExternalLink, RotateCcw, History, LogOut, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { DigitCard } from '@/components/digit/DigitCard';
 import { SubmitBar } from '@/components/digit/SubmitBar';
+import { mdmsService, boundaryService, hrmsService } from '@/api';
+
+interface TenantSummary {
+  loading: boolean;
+  error: string | null;
+  departments: number;
+  designations: number;
+  complaintTypes: number;
+  boundaries: number;
+  employees: number;
+}
+
+const INITIAL_SUMMARY: TenantSummary = {
+  loading: true,
+  error: null,
+  departments: 0,
+  designations: 0,
+  complaintTypes: 0,
+  boundaries: 0,
+  employees: 0,
+};
 
 export default function CompletePage() {
   const { state, logout } = useApp();
   const navigate = useNavigate();
+  const [summary, setSummary] = useState<TenantSummary>(INITIAL_SUMMARY);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // Fetch in parallel; swallow per-resource errors so one broken
+        // endpoint doesn't zero out the whole summary.
+        const [departments, designations, complaintTypes, boundaries, employees] = await Promise.all([
+          mdmsService.getDepartments(state.tenant).catch(() => [] as unknown[]),
+          mdmsService.getDesignations(state.tenant).catch(() => [] as unknown[]),
+          mdmsService.getComplaintTypes(state.tenant).catch(() => [] as unknown[]),
+          boundaryService.searchBoundaries(state.tenant).catch(() => [] as unknown[]),
+          hrmsService.searchEmployees(state.tenant).catch(() => [] as unknown[]),
+        ]);
+        if (cancelled) return;
+        setSummary({
+          loading: false,
+          error: null,
+          departments: departments.length,
+          designations: designations.length,
+          complaintTypes: complaintTypes.length,
+          boundaries: boundaries.length,
+          employees: employees.length,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setSummary((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : 'Failed to load summary',
+        }));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [state.tenant]);
 
   const handleLogout = () => {
     logout();
@@ -19,6 +79,16 @@ export default function CompletePage() {
     // In real app, would reset state
     navigate('/phase/1');
   };
+
+  // Render helper: "…" while loading, otherwise the count.
+  const cell = (value: number, suffix: string) =>
+    summary.loading ? (
+      <span className="inline-flex items-center gap-1 text-muted-foreground">
+        <Loader2 className="w-3 h-3 animate-spin" /> loading
+      </span>
+    ) : (
+      `${value} ${suffix}`
+    );
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -68,28 +138,40 @@ export default function CompletePage() {
                 <TableHeader>
                   <TableRow className="bg-muted/50">
                     <TableHead className="text-xs sm:text-sm font-condensed">Phase</TableHead>
-                    <TableHead className="text-xs sm:text-sm font-condensed">Items Created</TableHead>
+                    <TableHead className="text-xs sm:text-sm font-condensed">Records at tenant</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
                   <TableRow>
                     <TableCell className="text-xs sm:text-sm">Phase 1: Tenant & Branding</TableCell>
-                    <TableCell className="text-primary text-xs sm:text-sm font-medium">1 tenant, branding configured</TableCell>
+                    <TableCell className="text-primary text-xs sm:text-sm font-medium">{state.tenant}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="text-xs sm:text-sm">Phase 2: Boundary Setup</TableCell>
-                    <TableCell className="text-primary text-xs sm:text-sm font-medium">13 boundaries (ADMIN hierarchy)</TableCell>
+                    <TableCell className="text-primary text-xs sm:text-sm font-medium">{cell(summary.boundaries, 'boundaries')}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="text-xs sm:text-sm">Phase 3: Common Masters</TableCell>
-                    <TableCell className="text-primary text-xs sm:text-sm font-medium">3 depts, 5 desigs, 5 complaint types</TableCell>
+                    <TableCell className="text-primary text-xs sm:text-sm font-medium">
+                      {summary.loading ? (
+                        <span className="inline-flex items-center gap-1 text-muted-foreground"><Loader2 className="w-3 h-3 animate-spin" /> loading</span>
+                      ) : (
+                        `${summary.departments} depts, ${summary.designations} desigs, ${summary.complaintTypes} complaint types`
+                      )}
+                    </TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="text-xs sm:text-sm">Phase 4: Employees</TableCell>
-                    <TableCell className="text-primary text-xs sm:text-sm font-medium">4 employees with user accounts</TableCell>
+                    <TableCell className="text-primary text-xs sm:text-sm font-medium">{cell(summary.employees, 'employees')}</TableCell>
                   </TableRow>
                 </TableBody>
               </Table>
+              {summary.error && (
+                <p className="text-xs text-destructive mt-2">Failed to load counts: {summary.error}</p>
+              )}
+              <p className="text-[11px] text-muted-foreground mt-2">
+                Counts reflect the current total at tenant <code>{state.tenant}</code> — including any data present from earlier setup sessions. To see only what this walk created, browse the Management UI and filter by code prefix.
+              </p>
             </div>
           </div>
         </div>

--- a/src/pages/CompletePage.tsx
+++ b/src/pages/CompletePage.tsx
@@ -183,12 +183,34 @@ export default function CompletePage() {
             <strong className="text-sm font-condensed">Your complaints management system is ready!</strong>
           </div>
           <ul className="text-xs sm:text-sm space-y-1 sm:space-y-2 text-foreground">
-            <li>• Employees can login at <strong className="break-all text-primary">{state.environment.replace('https://', '')}</strong></li>
+            <li>
+              • Employees can login at{' '}
+              <a
+                href={`${state.environment}/digit-ui/employee/user/login`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="break-all text-primary underline hover:opacity-80"
+              >
+                {state.environment.replace(/^https?:\/\//, '')}/digit-ui/employee/user/login
+              </a>
+            </li>
+            <li>
+              • Citizens can file complaints at{' '}
+              <a
+                href={`${state.environment}/digit-ui/citizen`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="break-all text-primary underline hover:opacity-80"
+              >
+                {state.environment.replace(/^https?:\/\//, '')}/digit-ui/citizen
+              </a>
+            </li>
             <li>• Access complaint management based on their roles</li>
             <li>• Handle complaints in their assigned jurisdictions</li>
           </ul>
           <p className="mt-3 sm:mt-4 pt-3 border-t border-success/20 text-xs sm:text-sm">
-            <strong>Default credentials:</strong> username / <code className="bg-muted px-1 rounded text-primary">eGov@123</code>
+            <strong>Default credentials:</strong> the employee's <em>code</em> (e.g. <code className="bg-muted px-1 rounded text-primary">TEST_EMP_001</code>) as username, password{' '}
+            <code className="bg-muted px-1 rounded text-primary">eGov@123</code>. HRMS overrides the supplied <code className="bg-muted px-1 rounded">userName</code> with the employee code on create — that's the value that actually authenticates.
           </p>
         </div>
 

--- a/src/pages/Phase1Page.tsx
+++ b/src/pages/Phase1Page.tsx
@@ -37,6 +37,37 @@ interface BrandingData {
   stateLogo?: string;
 }
 
+// User-facing copy for each branding asset. Keys mirror BrandingData so the
+// row renderer can iterate this list directly. Labels and descriptions are
+// what the user sees — the camelCase keys above are the wire / MDMS field
+// names and never appear in the UI now.
+const BRANDING_FIELDS: ReadonlyArray<{
+  key: keyof BrandingData;
+  label: string;
+  description: string;
+}> = [
+  {
+    key: 'logoUrl',
+    label: 'Header logo',
+    description: 'Top-left logo on every employee and citizen screen. Recommended: PNG with transparent background, at least 300 px wide.',
+  },
+  {
+    key: 'logoUrlWhite',
+    label: 'Header logo — dark mode',
+    description: 'Same logo, but light/white pixels for use on dark headers (e.g. dashboard mode). Same dimensions as the header logo.',
+  },
+  {
+    key: 'bannerUrl',
+    label: 'Citizen-portal banner',
+    description: 'Hero image at the top of the citizen-facing home page. Recommended: 1920 × 480 JPG.',
+  },
+  {
+    key: 'stateLogo',
+    label: 'County / state emblem',
+    description: 'Appears on PDF receipts and printed correspondence. SVG preferred so it scales cleanly.',
+  },
+];
+
 export default function Phase1Page() {
   const { completePhase, addUndo, state } = useApp();
   const navigate = useNavigate();
@@ -49,6 +80,9 @@ export default function Phase1Page() {
   // Parsed data
   const [tenantData, setTenantData] = useState<TenantExcelRow | null>(null);
   const [brandingData, setBrandingData] = useState<BrandingData>({});
+  // Per-row error so a bad upload surfaces inline next to the failed row,
+  // not at the top of the page where users miss it.
+  const [brandingErrors, setBrandingErrors] = useState<Partial<Record<keyof BrandingData, string>>>({});
   const [validation, setValidation] = useState<ValidationResult | null>(null);
 
   // Created tenant
@@ -162,21 +196,29 @@ export default function Phase1Page() {
   };
 
   const handleBrandingFileUpload = async (type: keyof BrandingData, file: File) => {
+    // Clear any prior error for this row before retrying.
+    setBrandingErrors(prev => ({ ...prev, [type]: undefined }));
     setLoading(true);
     setError(null);
 
-    try {
-      // Upload file to filestore
-      const result = await apiClient.uploadFile(file, 'branding');
-
-      // Update branding data with filestore ID
-      setBrandingData(prev => ({
+    // Basic client-side guard so users see the obvious cases instantly
+    // instead of waiting for a filestore round-trip.
+    if (!file.type.startsWith('image/')) {
+      setBrandingErrors(prev => ({
         ...prev,
-        [type]: result.fileStoreId,
+        [type]: `Expected an image file, got "${file.type || 'unknown'}".`,
       }));
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const result = await apiClient.uploadFile(file, 'branding');
+      setBrandingData(prev => ({ ...prev, [type]: result.fileStoreId }));
     } catch (err) {
       console.error('File upload error:', err);
-      setError('Failed to upload file. Please try again.');
+      const msg = err instanceof Error ? err.message : 'Upload failed';
+      setBrandingErrors(prev => ({ ...prev, [type]: msg }));
     } finally {
       setLoading(false);
     }
@@ -203,14 +245,14 @@ export default function Phase1Page() {
       'District Name',
     ];
     const tenantSample = [
-      'City A ULB',
-      'PG.CITYA',
-      'City',
-      'https://example.com/logo.png',
-      '28.6139',
-      '77.2090',
-      'City A',
-      'District A',
+      'My City Council',                       // Tenant Display Name*
+      'ke.mycity',                             // Tenant Code* — convention: <root>.<city>, lowercase
+      'City',                                  // Tenant Type*
+      '',                                      // Logo File Path* — leave blank to upload in Step 1.2
+      '-1.2921',                               // Latitude — example: Nairobi
+      '36.8219',                               // Longitude
+      'My City',                               // City Name
+      'My District',                           // District Name
     ];
     const tenantData = [tenantHeaders, tenantSample];
     const tenantSheet = XLSX.utils.aoa_to_sheet(tenantData);
@@ -222,14 +264,12 @@ export default function Phase1Page() {
     ];
     XLSX.utils.book_append_sheet(wb, tenantSheet, 'Tenant Info');
 
-    // Tenant Branding Details sheet
+    // Tenant Branding Details sheet — kept for back-compat. The recommended
+    // path now is to upload images in Step 1.2 (filestore IDs are auto-filled).
+    // Leaving these blank in the template is fine; only fill in if you have
+    // pre-existing public URLs you want to reuse.
     const brandingHeaders = ['Banner URL', 'Logo URL', 'Logo URL (White)', 'State Logo'];
-    const brandingSample = [
-      'https://example.com/banner.png',
-      'https://example.com/logo.png',
-      'https://example.com/logo-white.png',
-      'https://example.com/state-logo.png',
-    ];
+    const brandingSample = ['', '', '', ''];
     const brandingData = [brandingHeaders, brandingSample];
     const brandingSheet = XLSX.utils.aoa_to_sheet(brandingData);
     brandingSheet['!cols'] = [{ wch: 35 }, { wch: 35 }, { wch: 35 }, { wch: 35 }];
@@ -474,13 +514,13 @@ export default function Phase1Page() {
               </div>
             </TabsContent>
             <TabsContent value="branding">
-              {Object.keys(brandingData).some(k => brandingData[k as keyof BrandingData]) ? (
+              {BRANDING_FIELDS.some(({ key }) => brandingData[key]) ? (
                 <div className="space-y-2">
-                  {Object.entries(brandingData).map(([key, value]) => value && (
+                  {BRANDING_FIELDS.map(({ key, label }) => brandingData[key] && (
                     <div key={key} className="flex items-center gap-2 text-sm">
                       <Image className="w-4 h-4 text-muted-foreground" />
-                      <span className="text-muted-foreground">{key.replace(/([A-Z])/g, ' $1').trim()}:</span>
-                      <span className="font-medium truncate">{value}</span>
+                      <span className="text-muted-foreground">{label}:</span>
+                      <span className="font-medium truncate">{brandingData[key]}</span>
                     </div>
                   ))}
                 </div>
@@ -542,56 +582,70 @@ export default function Phase1Page() {
             <p className="text-sm sm:text-base text-muted-foreground">Created: {createdTenant.code} ({createdTenant.name})</p>
           </div>
 
-          <SubHeader>Step 1.2: State Branding Configuration</SubHeader>
+          <SubHeader>Step 1.2: Branding assets</SubHeader>
+          <p className="text-xs sm:text-sm text-muted-foreground -mt-2 mb-4">
+            Upload the images that appear on the citizen and employee portals for this tenant. All four are optional — leave any blank to fall back to DIGIT defaults.
+          </p>
 
           <div className="grid gap-3 sm:gap-4">
-            {(['bannerUrl', 'logoUrl', 'logoUrlWhite', 'stateLogo'] as const).map((key) => (
-              <div key={key} className="flex items-center gap-3 sm:gap-4 p-3 sm:p-4 border border-border rounded bg-card">
-                <div className="w-12 h-12 sm:w-16 sm:h-16 bg-muted rounded flex items-center justify-center flex-shrink-0">
-                  {brandingData[key] ? (
-                    <Check className="w-5 h-5 sm:w-6 sm:h-6 text-success" />
-                  ) : (
-                    <Image className="w-5 h-5 sm:w-6 sm:h-6 text-muted-foreground" />
-                  )}
+            {BRANDING_FIELDS.map(({ key, label, description }) => {
+              const uploaded = brandingData[key];
+              const rowError = brandingErrors[key];
+              return (
+                <div key={key} className="flex items-start gap-3 sm:gap-4 p-3 sm:p-4 border border-border rounded bg-card">
+                  <div className="w-12 h-12 sm:w-16 sm:h-16 bg-muted rounded flex items-center justify-center flex-shrink-0">
+                    {uploaded ? (
+                      <Check className="w-5 h-5 sm:w-6 sm:h-6 text-success" />
+                    ) : (
+                      <Image className="w-5 h-5 sm:w-6 sm:h-6 text-muted-foreground" />
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-medium text-foreground text-sm sm:text-base">{label}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+                    <p className="text-xs sm:text-sm text-muted-foreground mt-1 truncate">
+                      {uploaded ? <>Uploaded ✓ <span className="font-mono text-[11px]">(filestore id: {uploaded})</span></> : 'Not uploaded'}
+                    </p>
+                    {rowError && (
+                      <p className="text-xs text-destructive mt-1 flex items-start gap-1">
+                        <AlertCircle className="w-3 h-3 mt-0.5 flex-shrink-0" />
+                        <span>{rowError}</span>
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex gap-2 flex-shrink-0">
+                    {uploaded && (
+                      <Button variant="outline" size="sm" className="hidden sm:flex border-primary text-primary hover:bg-primary/10">
+                        <Eye className="w-4 h-4 mr-1" />
+                        Preview
+                      </Button>
+                    )}
+                    <label className="cursor-pointer">
+                      <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0];
+                          if (file) handleBrandingFileUpload(key, file);
+                        }}
+                      />
+                      <Button variant="outline" size="sm" asChild className="border-primary text-primary hover:bg-primary/10">
+                        <span>
+                          <Upload className="w-4 h-4 mr-1" />
+                          {uploaded ? 'Replace' : 'Upload'}
+                        </span>
+                      </Button>
+                    </label>
+                  </div>
                 </div>
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium text-foreground text-sm sm:text-base">{key.replace(/([A-Z])/g, ' $1').trim()}</p>
-                  <p className="text-xs sm:text-sm text-muted-foreground truncate">
-                    {brandingData[key] || 'Not uploaded'}
-                  </p>
-                </div>
-                <div className="flex gap-2">
-                  {brandingData[key] && (
-                    <Button variant="outline" size="sm" className="hidden sm:flex border-primary text-primary hover:bg-primary/10">
-                      <Eye className="w-4 h-4 mr-1" />
-                      Preview
-                    </Button>
-                  )}
-                  <label className="cursor-pointer">
-                    <input
-                      type="file"
-                      accept="image/*"
-                      className="hidden"
-                      onChange={(e) => {
-                        const file = e.target.files?.[0];
-                        if (file) handleBrandingFileUpload(key, file);
-                      }}
-                    />
-                    <Button variant="outline" size="sm" asChild className="border-primary text-primary hover:bg-primary/10">
-                      <span>
-                        <Upload className="w-4 h-4 mr-1" />
-                        Upload
-                      </span>
-                    </Button>
-                  </label>
-                </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
 
           <Alert variant="info" className="mt-4">
             <AlertDescription className="text-xs sm:text-sm">
-              Branding is optional. You can skip this step and configure branding later.
+              Branding is optional. You can skip any row and configure these later from Management → Tenants.
             </AlertDescription>
           </Alert>
 

--- a/src/pages/Phase3Page.tsx
+++ b/src/pages/Phase3Page.tsx
@@ -112,6 +112,15 @@ export default function Phase3Page() {
 
     try {
       // Create departments
+      // Track outcomes locally — React state updates don't reflect into the
+      // captured variable until the next render, so reading createdDepts /
+      // createdDesigs / createdComplaints inside this same async block always
+      // returns 0 (the initial state). The toast strings below need the real
+      // counts from this run, hence the local mirrors.
+      let deptsCreated = 0;
+      let desigsCreated = 0;
+      let complaintsCreated = 0;
+
       if (departments.length > 0) {
         setProgressMessage('Creating departments...');
         const deptResults = await mdmsService.createDepartments(
@@ -122,7 +131,8 @@ export default function Phase3Page() {
             active: d.active,
           }))
         );
-        setCreatedDepts(deptResults.success.length);
+        deptsCreated = deptResults.success.length;
+        setCreatedDepts(deptsCreated);
 
         // Create localizations for departments
         await localizationService.uploadDepartmentLocalizations(
@@ -147,7 +157,8 @@ export default function Phase3Page() {
             active: d.active,
           }))
         );
-        setCreatedDesigs(desigResults.success.length);
+        desigsCreated = desigResults.success.length;
+        setCreatedDesigs(desigsCreated);
 
         // Create localizations for designations
         await localizationService.uploadDesignationLocalizations(
@@ -159,7 +170,7 @@ export default function Phase3Page() {
         setProgress(60);
       }
 
-      addUndo('create_departments', `Created ${createdDepts} departments and ${createdDesigs} designations`);
+      addUndo('create_departments', `Created ${deptsCreated} departments and ${desigsCreated} designations`);
 
       // Switch to complaint types
       setStep('creating-complaints');
@@ -179,7 +190,8 @@ export default function Phase3Page() {
             active: ct.active,
           }))
         );
-        setCreatedComplaints(complaintResults.success.length);
+        complaintsCreated = complaintResults.success.length;
+        setCreatedComplaints(complaintsCreated);
 
         // Create localizations for complaint types
         await localizationService.uploadComplaintTypeLocalizations(
@@ -194,7 +206,7 @@ export default function Phase3Page() {
         setProgress(100);
       }
 
-      addUndo('create_complaints', `Created ${createdComplaints} complaint types`);
+      addUndo('create_complaints', `Created ${complaintsCreated} complaint types`);
       setStep('complete');
     } catch (err) {
       console.error('MDMS creation error:', err);

--- a/src/pages/Phase3Page.tsx
+++ b/src/pages/Phase3Page.tsx
@@ -142,6 +142,7 @@ export default function Phase3Page() {
           designations.map(d => ({
             code: d.code,
             name: d.name,
+            description: d.description,
             department: d.department,
             active: d.active,
           }))

--- a/src/pages/Phase3Page.tsx
+++ b/src/pages/Phase3Page.tsx
@@ -172,7 +172,8 @@ export default function Phase3Page() {
           state.tenant,
           complaintTypes.map(ct => ({
             serviceCode: ct.serviceCode,
-            serviceName: ct.serviceName,
+            name: ct.name,
+            keywords: ct.keywords,
             department: ct.department,
             slaHours: ct.slaHours,
             active: ct.active,
@@ -185,7 +186,7 @@ export default function Phase3Page() {
           state.tenant,
           complaintTypes.map(ct => ({
             serviceCode: ct.serviceCode,
-            serviceName: ct.serviceName,
+            name: ct.name,
           })),
           'en_IN'
         );
@@ -492,7 +493,7 @@ export default function Phase3Page() {
                               </Badge>
                             </TableCell>
                             <TableCell className="font-mono text-xs sm:text-sm">{type.serviceCode}</TableCell>
-                            <TableCell className="text-xs sm:text-sm">{type.serviceName}</TableCell>
+                            <TableCell className="text-xs sm:text-sm">{type.name}</TableCell>
                             <TableCell className="text-xs sm:text-sm">{type.slaHours}h</TableCell>
                             <TableCell className="font-mono text-xs sm:text-sm">{type.department}</TableCell>
                           </TableRow>
@@ -586,7 +587,7 @@ export default function Phase3Page() {
                 ) : (
                   <Loader2 className="w-4 h-4 text-primary animate-spin" />
                 )}
-                <span>{type.serviceCode} - {type.serviceName}</span>
+                <span>{type.serviceCode} - {type.name}</span>
               </div>
             ))}
             {complaintTypes.length > 5 && (

--- a/src/pages/Phase4Page.tsx
+++ b/src/pages/Phase4Page.tsx
@@ -700,9 +700,19 @@ export default function Phase4Page() {
       {step === 'complete' && (
         <DigitCard>
           <Banner
-            successful={true}
-            message="Employees Created Successfully!"
-            info={`Tenant: ${state.tenant.toUpperCase()}`}
+            successful={createdCount > 0 && failedCount === 0}
+            message={
+              createdCount > 0 && failedCount === 0
+                ? 'Employees Created Successfully!'
+                : createdCount > 0
+                ? `Created ${createdCount}, ${failedCount} failed`
+                : `No employees created — ${failedCount} failed`
+            }
+            info={
+              failedCount > 0
+                ? `Tenant: ${state.tenant.toUpperCase()} • Check the failure list below and retry the failed rows.`
+                : `Tenant: ${state.tenant.toUpperCase()}`
+            }
           />
 
           <div className="mt-6 p-4 bg-muted rounded">

--- a/src/pages/Phase4Page.tsx
+++ b/src/pages/Phase4Page.tsx
@@ -243,6 +243,7 @@ export default function Phase4Page() {
             mobileNumber: emp.mobileNumber,
             emailId: emp.emailId,
             gender: emp.gender,
+            dob: emp.dob ? new Date(emp.dob).getTime() : undefined,
             department: emp.department,
             designation: emp.designation,
             roles,

--- a/src/utils/excelParser.ts
+++ b/src/utils/excelParser.ts
@@ -321,14 +321,10 @@ export function parseBoundaryExcel(workbook: XLSX.WorkBook): {
   }
 
   if (!sheet) {
-    sheet = workbook.Sheets[workbook.SheetNames[0]];
-  }
-
-  if (!sheet) {
     errors.push({
       field: 'file',
-      message: 'No valid boundary sheet found',
-      code: 'NO_SHEET',
+      message: `No boundary sheet found. Expected one of: ${sheetNames.join(', ')}. Got sheets in this file: ${workbook.SheetNames.join(', ')}.`,
+      code: 'WRONG_SHEET',
     });
     return { data: [], hierarchyLevels: [], validation: { valid: false, errors, warnings } };
   }
@@ -428,14 +424,10 @@ export function parseDepartmentExcel(workbook: XLSX.WorkBook): {
   }
 
   if (!sheet) {
-    sheet = workbook.Sheets[workbook.SheetNames[0]];
-  }
-
-  if (!sheet) {
     errors.push({
       field: 'file',
-      message: 'No valid department sheet found',
-      code: 'NO_SHEET',
+      message: `No department sheet found. Expected one of: Department, Departments, DepartmentMaster, department. Got sheets in this file: ${workbook.SheetNames.join(', ')}.`,
+      code: 'WRONG_SHEET',
     });
     return { data: [], validation: { valid: false, errors, warnings } };
   }
@@ -504,14 +496,10 @@ export function parseDesignationExcel(workbook: XLSX.WorkBook): {
   }
 
   if (!sheet) {
-    sheet = workbook.Sheets[workbook.SheetNames[0]];
-  }
-
-  if (!sheet) {
     errors.push({
       field: 'file',
-      message: 'No valid designation sheet found',
-      code: 'NO_SHEET',
+      message: `No designation sheet found. Expected one of: Designation, Designations, DesignationMaster, designation. Got sheets in this file: ${workbook.SheetNames.join(', ')}.`,
+      code: 'WRONG_SHEET',
     });
     return { data: [], validation: { valid: false, errors, warnings } };
   }
@@ -583,14 +571,10 @@ export function parseComplaintTypeExcel(workbook: XLSX.WorkBook): {
   }
 
   if (!sheet) {
-    sheet = workbook.Sheets[workbook.SheetNames[0]];
-  }
-
-  if (!sheet) {
     errors.push({
       field: 'file',
-      message: 'No valid complaint type sheet found',
-      code: 'NO_SHEET',
+      message: `No complainttype sheet found. Expected one of: ComplaintType, ComplaintTypes, ServiceDefs, servicedefs, PGR. Got sheets in this file: ${workbook.SheetNames.join(', ')}.`,
+      code: 'WRONG_SHEET',
     });
     return { data: [], validation: { valid: false, errors, warnings } };
   }
@@ -673,14 +657,10 @@ export function parseEmployeeExcel(workbook: XLSX.WorkBook): {
   }
 
   if (!sheet) {
-    sheet = workbook.Sheets[workbook.SheetNames[0]];
-  }
-
-  if (!sheet) {
     errors.push({
       field: 'file',
-      message: 'No valid employee sheet found',
-      code: 'NO_SHEET',
+      message: `No employee sheet found. Expected one of: Employee, Employees, EmployeeMaster, HRMS, employee. Got sheets in this file: ${workbook.SheetNames.join(', ')}.`,
+      code: 'WRONG_SHEET',
     });
     return { data: [], validation: { valid: false, errors, warnings } };
   }

--- a/src/utils/excelParser.ts
+++ b/src/utils/excelParser.ts
@@ -521,7 +521,9 @@ export function parseDesignationExcel(workbook: XLSX.WorkBook): {
   jsonData.forEach((row, index) => {
     const code = String(row['code'] || row['Code'] || row['designationCode'] || '').trim();
     const name = String(row['name'] || row['Name'] || row['designationName'] || '').trim();
-    const department = String(row['department'] || row['Department'] || '').trim() || undefined;
+    const description = String(row['description'] || row['Description'] || '').trim() || name;
+    const deptRaw = String(row['department'] || row['Department'] || '').trim();
+    const department = deptRaw ? deptRaw.split(',').map(s => s.trim()).filter(Boolean) : undefined;
     const activeStr = String(row['active'] || row['Active'] || row['isActive'] || 'true').trim().toLowerCase();
     const active = activeStr === 'true' || activeStr === 'yes' || activeStr === '1';
 
@@ -545,7 +547,7 @@ export function parseDesignationExcel(workbook: XLSX.WorkBook): {
       return;
     }
 
-    designations.push({ code, name, department, active });
+    designations.push({ code, name, description, department, active });
   });
 
   return {

--- a/src/utils/excelParser.ts
+++ b/src/utils/excelParser.ts
@@ -599,7 +599,9 @@ export function parseComplaintTypeExcel(workbook: XLSX.WorkBook): {
 
   jsonData.forEach((row, index) => {
     const serviceCode = String(row['serviceCode'] || row['ServiceCode'] || row['code'] || '').trim();
-    const serviceName = String(row['serviceName'] || row['ServiceName'] || row['name'] || '').trim();
+    const name = String(row['name'] || row['Name'] || row['serviceName'] || row['ServiceName'] || '').trim();
+    const keywordsRaw = String(row['keywords'] || row['Keywords'] || '').trim();
+    const keywords = keywordsRaw || name.toLowerCase().replace(/\s+/g, ',');
     const department = String(row['department'] || row['Department'] || '').trim();
     const slaHours = parseInt(String(row['slaHours'] || row['SlaHours'] || row['sla'] || '24'), 10) || 24;
     const activeStr = String(row['active'] || row['Active'] || row['isActive'] || 'true').trim().toLowerCase();
@@ -615,10 +617,10 @@ export function parseComplaintTypeExcel(workbook: XLSX.WorkBook): {
       return;
     }
 
-    if (!serviceName) {
+    if (!name) {
       errors.push({
         row: index + 2,
-        field: 'serviceName',
+        field: 'name',
         message: 'Service name is required',
         code: 'REQUIRED_FIELD',
       });
@@ -635,7 +637,7 @@ export function parseComplaintTypeExcel(workbook: XLSX.WorkBook): {
       return;
     }
 
-    complaintTypes.push({ serviceCode, serviceName, department, slaHours, active });
+    complaintTypes.push({ serviceCode, name, keywords, department, slaHours, active });
   });
 
   return {

--- a/src/utils/excelParser.ts
+++ b/src/utils/excelParser.ts
@@ -694,6 +694,7 @@ export function parseEmployeeExcel(workbook: XLSX.WorkBook): {
     const mobileNumber = String(row['mobileNumber'] || row['MobileNumber'] || row['mobile'] || row['phone'] || '').trim();
     const emailId = String(row['emailId'] || row['EmailId'] || row['email'] || '').trim() || undefined;
     const gender = String(row['gender'] || row['Gender'] || '').trim() || undefined;
+    const dob = String(row['dob'] || row['DOB'] || row['dateOfBirth'] || '').trim() || undefined;
     const department = String(row['department'] || row['Department'] || '').trim();
     const designation = String(row['designation'] || row['Designation'] || '').trim();
     const roles = String(row['roles'] || row['Roles'] || row['role'] || 'EMPLOYEE').trim();
@@ -783,6 +784,7 @@ export function parseEmployeeExcel(workbook: XLSX.WorkBook): {
       mobileNumber,
       emailId,
       gender,
+      dob,
       department,
       designation,
       roles,


### PR DESCRIPTION
## Summary

Seven FE-only fixes for payload shape mismatches and silent-failure modes in the onboarding flow. Each was surfaced while walking Phase 1 → 4 end-to-end against a live DIGIT backend (naipepea 2026-04-21). No backend changes required — the MDMS/HRMS/boundary-service schemas are the source of truth, and the FE was sending the wrong shape.

Related PR on the old monorepo location: `ChakshuGautam/Citizen-Complaint-Resolution-System#12` (closed — superseded by this one).

## Commits

| Commit | Fix |
|---|---|
| `d30ae08` | `createTenant.data.tenantId` was set to `tenant.code` (self-reference); must be the parent `stateTenantId` |
| `555a512` | Designation payload: populate `description` + send `department` as `string[]` through the full parser → page → service pipeline |
| `6987238` | ComplaintType: rename `serviceName` → `name` everywhere in the TS surface, add `keywords` as a first-class Excel column |
| `4dae520` | HRMS `user.dob` was missing — every Phase 4 upload 4xx'd with `NotNull.employeeRequest.employees[0].user.dob` |
| `c561f65` | `searchBoundaries` hit `/boundary/_search` (flat-entity lookup) when it needed `/boundary-relationships/_search` (tree walk); also dedupes the response since the relationships endpoint duplicates children |
| `91ebc98` | `createBoundaryEntity` / `createBoundaryRelationship` blanket-swallowed any "already exists" error — but the backend returns this spuriously for rows that never persisted. Verify first, re-throw with diagnostics if the record really isn't there. |
| `de882a4` | `createHierarchy` cast an array response to a single object → `selectedHierarchy.hierarchyType = undefined` → Phase 2 skipped every relationship-create call (the quietest of the bugs). |

Every commit has a **Context / Failure / Fix** body explaining what broke, why, and what changed. Read `git log --oneline --no-merges origin/main..fix/onboarding-payload-shapes` plus `git show` for the per-commit detail.

## Reproduction before this PR

Phase 1 (tenant creation):
```
{"Errors":[{"code":"INVALID_REQUEST","message":"required key [tenantId] not found"}]}
# or — if tenantId was the self-code — silent semantic bug, no tree inheritance
```

Phase 3 (designation):
```
{"Errors":[{"code":"INVALID_REQUEST","message":"required key [description] not found"}]}
# (also: single-department string works but multi-dept Excel rows got truncated)
```

Phase 3 (complaint type — after `RAINMAKER-PGR.ServiceDefs` was fixed):
```
# the FE renamed at send-time but the Excel parser / page still called it serviceName,
# and keywords was always auto-generated from `serviceName.toLowerCase()`, ignoring
# any Keywords column the user filled in.
```

Phase 4 (employee):
```
{"Errors":[{"code":"NotNull.employeeRequest.employees[0].user.dob",
            "message":"must not be null"}]}
```

Phase 2 (boundaries) — most interesting failure mode:
- Phase 2 UI shows "✓ 4 boundaries created"
- DB has 4 boundary entities, **0 relationships**
- Phase 4 then: `Boundaries: 0 loaded` → every employee fails with `Boundary TEST_WARD_X not found`

Root cause of Phase 2's silent failure is the `createHierarchy` array-cast bug (`de882a4`): once `selectedHierarchy.hierarchyType` is undefined, the FE never even calls `/boundary-relationships/_create`. The "already exists" swallower (`91ebc98`) compounded by treating spurious cache-layer errors as success.

## Verification

All seven fixes verified end-to-end on a live DIGIT instance (naipepea) with dummy tenant `ke.testzone`, hierarchy `ONBOARDTEST`, 4 boundaries, 2 departments, 1 designation, 2 complaint types, 1 employee. Cleanup SQL and Excel test fixtures available in `Nai Pepea/onboarding-test-assets/` in an adjacent workspace.

## Test plan

- [ ] Phase 1 upload creates a child tenant; verify `data.tenantId` is the parent in MDMS search
- [ ] Phase 2 create-new-hierarchy → upload 4 boundaries → verify **4 relationships** in boundary_relationship (not just 4 entities in boundary)
- [ ] Phase 3 upload with a Designation sheet including a `description` column and comma-separated `department` column → verify round-trip through MDMS search
- [ ] Phase 3 with a `keywords` column → verify keywords land on the ServiceDefs record (not auto-generated from name)
- [ ] Phase 3 with legacy `serviceName` column header → backward-compat fallback still works
- [ ] Phase 4 upload with `dob` column → verify `user.dob` on the created employee
- [ ] Phase 4 upload WITHOUT a dob column → verify default of 1990-01-01 UTC (HRMS accepts, employee lands)
- [ ] Phase 2 retry (with state already seeded) → "already exists" is swallowed because the record really is there

## Follow-ups

- **`generateUsername` in hrmsService is dead code** — HRMS overrides `user.userName` with `employee.code` on create. Worth removing for clarity, not touched here.
- **Schema-driven payload construction** — 6 of 7 bugs here are the same shape: the FE hand-builds a JSON object from developer memory of the MDMS schema, and the memory drifts. The configurator already fetches schemas via `/mdms-v2/schema/v1/_search` for ajv validation in the typed edit page. Reusing that schema to *build* outgoing payloads (instead of validating only) would make this whole class of bug impossible. Separate PR worth considering.
- **Phase 4 DOB as a proper field** — we default to 1990-01-01 when absent. A real deployment wants DOB surfaced as either a form field or a required Excel column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Employee bulk uploads now accept DOB and use it when present.
  * Added explicit existence checks for boundary entities and relationships.

* **Enhancements**
  * Improved boundary hierarchy handling, flattening, propagation and deduplication.
  * Complaint types and uploads now use a unified name + required keywords.
  * Designations now include descriptions and support multiple departments.
  * Complete/summary pages show dynamic counts and loading/error states.
  * Branding upload UI and templates improved with per-item validation and errors.

* **Tests**
  * Added resource registry coverage and cleanup assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->