### PR TITLE
HRMS / Employee management — full-coverage Create + Edit

### DIFF
--- a/src/admin/DigitCreate.tsx
+++ b/src/admin/DigitCreate.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CreateBase, useCreateContext, Form } from 'ra-core';
+import { CreateBase, useCreateContext, Form, type TransformData } from 'ra-core';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Save, RefreshCw } from 'lucide-react';
 import { DigitCard } from '@/components/digit/DigitCard';
@@ -17,6 +17,8 @@ export interface DigitCreateProps {
   record?: Record<string, unknown>;
   /** Where to redirect after successful creation (default: "list") */
   redirect?: 'list' | 'edit' | 'show' | false;
+  /** Optional pre-submit transform (stamp server-required nested fields, etc.) */
+  transform?: TransformData;
 }
 
 function DigitCreateContent({
@@ -86,9 +88,9 @@ function DigitCreateContent({
   );
 }
 
-export function DigitCreate({ title, children, resource, record, redirect = 'list' }: DigitCreateProps) {
+export function DigitCreate({ title, children, resource, record, redirect = 'list', transform }: DigitCreateProps) {
   return (
-    <CreateBase resource={resource} record={record} redirect={redirect}>
+    <CreateBase resource={resource} record={record} redirect={redirect} transform={transform}>
       <DigitCreateContent title={title}>{children}</DigitCreateContent>
     </CreateBase>
   );

--- a/src/admin/DigitCreate.tsx
+++ b/src/admin/DigitCreate.tsx
@@ -5,6 +5,11 @@ import { ArrowLeft, Save, RefreshCw } from 'lucide-react';
 import { DigitCard } from '@/components/digit/DigitCard';
 import { ActionBar } from '@/components/digit/ActionBar';
 import { Button } from '@/components/ui/button';
+import {
+  useMutationError,
+  MutationErrorBanner,
+  type MutationErrorInfo,
+} from './mutationError';
 
 export interface DigitCreateProps {
   /** Page title */
@@ -24,9 +29,13 @@ export interface DigitCreateProps {
 function DigitCreateContent({
   title,
   children,
+  errorInfo,
+  onDismissError,
 }: {
   title?: string;
   children: React.ReactNode;
+  errorInfo: MutationErrorInfo | null;
+  onDismissError: () => void;
 }) {
   const { saving, defaultTitle } = useCreateContext();
   const navigate = useNavigate();
@@ -43,7 +52,6 @@ function DigitCreateContent({
 
   return (
     <div className="space-y-4">
-      {/* Header */}
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="sm" onClick={handleBack} className="gap-1.5">
           <ArrowLeft className="w-4 h-4" />
@@ -57,8 +65,8 @@ function DigitCreateContent({
         )}
       </div>
 
-      {/* Form card */}
       <DigitCard className="max-w-none">
+        <MutationErrorBanner info={errorInfo} onDismiss={onDismissError} />
         <Form>
           <div className="space-y-4">
             {children}
@@ -89,9 +97,21 @@ function DigitCreateContent({
 }
 
 export function DigitCreate({ title, children, resource, record, redirect = 'list', transform }: DigitCreateProps) {
+  const { info, capture, clear } = useMutationError();
   return (
-    <CreateBase resource={resource} record={record} redirect={redirect} transform={transform}>
-      <DigitCreateContent title={title}>{children}</DigitCreateContent>
+    <CreateBase
+      resource={resource}
+      record={record}
+      redirect={redirect}
+      transform={transform}
+      mutationOptions={{
+        onError: (err) => capture(err),
+        onSuccess: () => clear(),
+      }}
+    >
+      <DigitCreateContent title={title} errorInfo={info} onDismissError={clear}>
+        {children}
+      </DigitCreateContent>
     </CreateBase>
   );
 }

--- a/src/admin/DigitEdit.tsx
+++ b/src/admin/DigitEdit.tsx
@@ -5,6 +5,11 @@ import { ArrowLeft, Save, RefreshCw } from 'lucide-react';
 import { DigitCard } from '@/components/digit/DigitCard';
 import { ActionBar } from '@/components/digit/ActionBar';
 import { Button } from '@/components/ui/button';
+import {
+  useMutationError,
+  MutationErrorBanner,
+  type MutationErrorInfo,
+} from './mutationError';
 
 export interface DigitEditProps {
   /** Page title */
@@ -22,9 +27,13 @@ export interface DigitEditProps {
 function DigitEditContent({
   title,
   children,
+  errorInfo,
+  onDismissError,
 }: {
   title?: string;
   children: React.ReactNode;
+  errorInfo: MutationErrorInfo | null;
+  onDismissError: () => void;
 }) {
   const { record, isPending, saving, error, defaultTitle, refetch } =
     useEditContext();
@@ -101,6 +110,7 @@ function DigitEditContent({
 
       {/* Form card */}
       <DigitCard className="max-w-none">
+        <MutationErrorBanner info={errorInfo} onDismiss={onDismissError} />
         <Form>
           <div className="space-y-4">
             {children}
@@ -131,9 +141,21 @@ function DigitEditContent({
 }
 
 export function DigitEdit({ title, children, resource, id, transform }: DigitEditProps) {
+  const { info, capture, clear } = useMutationError();
   return (
-    <EditBase resource={resource} id={id} mutationMode="pessimistic" transform={transform}>
-      <DigitEditContent title={title}>{children}</DigitEditContent>
+    <EditBase
+      resource={resource}
+      id={id}
+      mutationMode="pessimistic"
+      transform={transform}
+      mutationOptions={{
+        onError: (err) => capture(err),
+        onSuccess: () => clear(),
+      }}
+    >
+      <DigitEditContent title={title} errorInfo={info} onDismissError={clear}>
+        {children}
+      </DigitEditContent>
     </EditBase>
   );
 }

--- a/src/admin/DigitEdit.tsx
+++ b/src/admin/DigitEdit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { EditBase, useEditContext, Form } from 'ra-core';
+import { EditBase, useEditContext, Form, type TransformData } from 'ra-core';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Save, RefreshCw } from 'lucide-react';
 import { DigitCard } from '@/components/digit/DigitCard';
@@ -15,6 +15,8 @@ export interface DigitEditProps {
   resource?: string;
   /** Record id (optional, from URL by default) */
   id?: string | number;
+  /** Optional pre-submit transform */
+  transform?: TransformData;
 }
 
 function DigitEditContent({
@@ -128,9 +130,9 @@ function DigitEditContent({
   );
 }
 
-export function DigitEdit({ title, children, resource, id }: DigitEditProps) {
+export function DigitEdit({ title, children, resource, id, transform }: DigitEditProps) {
   return (
-    <EditBase resource={resource} id={id} mutationMode="pessimistic">
+    <EditBase resource={resource} id={id} mutationMode="pessimistic" transform={transform}>
       <DigitEditContent title={title}>{children}</DigitEditContent>
     </EditBase>
   );

--- a/src/admin/hrms/useRolesLookup.ts
+++ b/src/admin/hrms/useRolesLookup.ts
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useGetList } from 'ra-core';
+import type { Role } from '@/api/types';
+
+export interface UseRolesLookupResult {
+  roles: Role[];
+  isLoading: boolean;
+  isError: boolean;
+  buildRole: (code: string, tenantId: string) => Role;
+}
+
+export function useRolesLookup(): UseRolesLookupResult {
+  const { data, isLoading, isError } = useGetList('access-roles', {
+    pagination: { page: 1, perPage: 500 },
+    sort: { field: 'name', order: 'ASC' },
+  });
+
+  const roles = useMemo<Role[]>(() => {
+    if (!data) return [];
+    return data.map((record) => {
+      const code = String((record as Record<string, unknown>).code ?? record.id);
+      const name = String((record as Record<string, unknown>).name ?? code);
+      const descriptionRaw = (record as Record<string, unknown>).description;
+      const role: Role = { code, name };
+      if (typeof descriptionRaw === 'string') role.description = descriptionRaw;
+      return role;
+    });
+  }, [data]);
+
+  const buildRole = useMemo(() => {
+    return (code: string, tenantId: string): Role => {
+      const found = roles.find((r) => r.code === code);
+      return { code, name: found?.name ?? code, tenantId };
+    };
+  }, [roles]);
+
+  return { roles, isLoading, isError: Boolean(isError), buildRole };
+}

--- a/src/admin/mutationError.tsx
+++ b/src/admin/mutationError.tsx
@@ -1,0 +1,74 @@
+import { useState, useCallback } from 'react';
+import { AlertCircle, X } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+export interface MutationErrorInfo {
+  message: string;
+  code?: string;
+  statusCode?: number;
+}
+
+export function extractMutationError(err: unknown): MutationErrorInfo {
+  if (!err) return { message: 'Unknown error' };
+  if (typeof err === 'object') {
+    const e = err as Record<string, unknown>;
+    const errorsArr = Array.isArray(e.errors) ? (e.errors as Array<Record<string, unknown>>) : null;
+    if (errorsArr && errorsArr[0]) {
+      const message =
+        (typeof errorsArr[0].message === 'string' && errorsArr[0].message) ||
+        (typeof errorsArr[0].code === 'string' && errorsArr[0].code) ||
+        'Unknown error';
+      const code = typeof errorsArr[0].code === 'string' ? errorsArr[0].code : undefined;
+      const statusCode = typeof e.statusCode === 'number' ? e.statusCode : undefined;
+      return { message, code, statusCode };
+    }
+    if (typeof e.message === 'string') {
+      const statusCode = typeof e.statusCode === 'number' ? e.statusCode : undefined;
+      return { message: e.message, statusCode };
+    }
+  }
+  return { message: String(err) };
+}
+
+export function useMutationError() {
+  const [info, setInfo] = useState<MutationErrorInfo | null>(null);
+  const capture = useCallback((err: unknown) => setInfo(extractMutationError(err)), []);
+  const clear = useCallback(() => setInfo(null), []);
+  return { info, capture, clear };
+}
+
+interface BannerProps {
+  info: MutationErrorInfo | null;
+  onDismiss: () => void;
+}
+
+export function MutationErrorBanner({ info, onDismiss }: BannerProps) {
+  if (!info) return null;
+  return (
+    <Alert variant="destructive" className="mb-4">
+      <AlertCircle className="h-4 w-4" />
+      <AlertDescription>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="font-medium">Save failed</p>
+            <p className="text-sm mt-0.5 break-words">{info.message}</p>
+            {(info.code || info.statusCode) && (
+              <p className="text-xs opacity-70 mt-1 font-mono">
+                {info.statusCode ? `${info.statusCode} · ` : ''}
+                {info.code ?? ''}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss error"
+            className="shrink-0 hover:opacity-70"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -26,6 +26,7 @@ export const ENDPOINTS = {
   BOUNDARY_RELATIONSHIP_SEARCH: '/boundary-service/boundary-relationships/_search',
 
   // HRMS
+  // KEEP IN SYNC with packages/data-provider/src/client/endpoints.ts
   HRMS_EMPLOYEES_SEARCH: '/egov-hrms/employees/_search',
   HRMS_EMPLOYEES_CREATE: '/egov-hrms/employees/_create',
   HRMS_EMPLOYEES_UPDATE: '/egov-hrms/employees/_update',
@@ -61,12 +62,3 @@ export const OAUTH_CONFIG = {
 
 // Default employee password
 export const DEFAULT_PASSWORD = 'eGov@123';
-
-// Common roles for PGR/CRS
-export const PGR_ROLES = [
-  { code: 'EMPLOYEE', name: 'Employee', description: 'Basic employee role' },
-  { code: 'PGR_LME', name: 'Last Mile Employee', description: 'Handles complaints on ground' },
-  { code: 'GRO', name: 'Grievance Routing Officer', description: 'Routes complaints to departments' },
-  { code: 'PGR_ADMIN', name: 'PGR Administrator', description: 'Admin access to PGR module' },
-  { code: 'SUPERUSER', name: 'Super User', description: 'Full system access' },
-];

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,6 @@
 // DIGIT API - Main Export
 export { apiClient, ApiClientError, DigitApiClient } from './client';
-export { getApiBaseUrl, ENDPOINTS, MDMS_SCHEMAS, OAUTH_CONFIG, DEFAULT_PASSWORD, PGR_ROLES } from './config';
+export { getApiBaseUrl, ENDPOINTS, MDMS_SCHEMAS, OAUTH_CONFIG, DEFAULT_PASSWORD } from './config';
 
 // Services
 export { mdmsService } from './services/mdms';

--- a/src/api/services/hrms.ts
+++ b/src/api/services/hrms.ts
@@ -42,11 +42,69 @@ export const hrmsService = {
   },
 
   // ============================================
+  // Uniqueness Pre-flights
+  // ============================================
+
+  // Returns true when no existing EMPLOYEE user on the tenant owns the username.
+  // Any failure (network / rate-limit) falls back to "assume available"; HRMS
+  // will surface real conflicts as 4xx on _create.
+  async checkUsernameAvailable(tenantId: string, userName: string): Promise<boolean> {
+    try {
+      const response = await apiClient.post(ENDPOINTS.USER_SEARCH, {
+        RequestInfo: apiClient.buildRequestInfo({ action: '_search' }),
+        tenantId,
+        userName: [userName],
+        userType: 'EMPLOYEE',
+      });
+      const users = (response.user || []) as unknown[];
+      return users.length === 0;
+    } catch (err) {
+      console.warn('checkUsernameAvailable pre-flight failed; assuming available', err);
+      return true;
+    }
+  },
+
+  // Returns true when no existing EMPLOYEE user on the tenant owns the mobile.
+  async checkMobileAvailable(tenantId: string, mobileNumber: string): Promise<boolean> {
+    try {
+      const response = await apiClient.post(ENDPOINTS.USER_SEARCH, {
+        RequestInfo: apiClient.buildRequestInfo({ action: '_search' }),
+        tenantId,
+        mobileNumber,
+        userType: 'EMPLOYEE',
+      });
+      const users = (response.user || []) as unknown[];
+      return users.length === 0;
+    } catch (err) {
+      console.warn('checkMobileAvailable pre-flight failed; assuming available', err);
+      return true;
+    }
+  },
+
+  // ============================================
   // Employee Creation
   // ============================================
 
   // Create a single employee
   async createEmployee(employee: Employee): Promise<Employee> {
+    const tenantId = employee.tenantId;
+    const userName = employee.user?.userName;
+    const mobileNumber = employee.user?.mobileNumber;
+
+    if (tenantId && userName) {
+      const usernameAvailable = await this.checkUsernameAvailable(tenantId, userName);
+      if (!usernameAvailable) {
+        throw new Error(`Username "${userName}" already exists on tenant ${tenantId}`);
+      }
+    }
+
+    if (tenantId && mobileNumber) {
+      const mobileAvailable = await this.checkMobileAvailable(tenantId, mobileNumber);
+      if (!mobileAvailable) {
+        throw new Error(`Mobile "${mobileNumber}" already exists on tenant ${tenantId}`);
+      }
+    }
+
     const response = await apiClient.post(ENDPOINTS.HRMS_EMPLOYEES_CREATE, {
       RequestInfo: apiClient.buildRequestInfo({ action: '_create' }),
       Employees: [employee],
@@ -101,7 +159,7 @@ export const hrmsService = {
     mobileNumber: string;
     emailId?: string;
     gender?: string;
-    dob?: number;
+    dob: number;
     department: string;
     designation: string;
     roles: Role[];
@@ -110,12 +168,6 @@ export const hrmsService = {
     password?: string;
   }): Employee {
     const now = Date.now();
-    // HRMS validates user.dob with @NotNull. If the caller didn't provide
-    // one, fall back to 1990-01-01 UTC — otherwise the create fails the
-    // whole batch with NotNull.employeeRequest.employees[0].user.dob.
-    // TODO: surface DOB as a proper form field / Excel column so we're
-    // not silently defaulting real data.
-    const dob = data.dob ?? Date.UTC(1990, 0, 1);
 
     const user: EmployeeUser = {
       userName: data.userName.toLowerCase(),
@@ -124,7 +176,7 @@ export const hrmsService = {
       mobileNumber: data.mobileNumber,
       emailId: data.emailId,
       gender: data.gender,
-      dob,
+      dob: data.dob,
       type: 'EMPLOYEE',
       active: true,
       tenantId: data.tenantId,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -393,7 +393,7 @@ export interface EmployeeExcelRow {
   mobileNumber: string;
   emailId?: string;
   gender?: string;
-  dob?: string;
+  dob: string;
   department: string;
   designation: string;
   roles: string; // comma-separated

--- a/src/pages/Phase4Page.tsx
+++ b/src/pages/Phase4Page.tsx
@@ -34,7 +34,6 @@ import {
   boundaryService,
   hrmsService,
   ApiClientError,
-  PGR_ROLES,
 } from '@/api';
 import { parseExcelFile, parseEmployeeExcel } from '@/utils/excelParser';
 import type {
@@ -67,6 +66,7 @@ export default function Phase4Page() {
   const [departments, setDepartments] = useState<Department[]>([]);
   const [designations, setDesignations] = useState<Designation[]>([]);
   const [boundaries, setBoundaries] = useState<Boundary[]>([]);
+  const [roles, setRoles] = useState<{ code: string; name: string; description?: string }[]>([]);
   const [loadingRefs, setLoadingRefs] = useState(false);
 
   // Parsed employee data
@@ -86,20 +86,18 @@ export default function Phase4Page() {
   const fetchReferenceData = async () => {
     setLoadingRefs(true);
     try {
-      // Fetch departments
-      const depts = await mdmsService.getDepartments(state.tenant);
+      const [depts, desigs, bounds, fetchedRoles] = await Promise.all([
+        mdmsService.getDepartments(state.tenant),
+        mdmsService.getDesignations(state.tenant),
+        boundaryService.searchBoundaries(state.tenant),
+        mdmsService.getRoles(state.tenant).catch(() => [] as typeof roles),
+      ]);
       setDepartments(depts);
-
-      // Fetch designations
-      const desigs = await mdmsService.getDesignations(state.tenant);
       setDesignations(desigs);
-
-      // Fetch boundaries
-      const bounds = await boundaryService.searchBoundaries(state.tenant);
       setBoundaries(bounds);
+      setRoles(fetchedRoles);
     } catch (err) {
       console.error('Failed to fetch reference data:', err);
-      // Don't show error - will validate on upload
     } finally {
       setLoadingRefs(false);
     }
@@ -146,7 +144,7 @@ export default function Phase4Page() {
     const deptCodes = departments.map((d) => d.code);
     const desigCodes = designations.map((d) => d.code);
     const boundaryCodes = boundaries.map((b) => b.code);
-    const validRoles = PGR_ROLES.map((r) => r.code);
+    const validRoles = roles.map((r) => r.code);
 
     return rawEmployees.map((emp) => {
       const errors: string[] = [];
@@ -186,6 +184,11 @@ export default function Phase4Page() {
         errors.push('Invalid mobile number');
       }
 
+      // Validate DOB (parser guarantees string, but double-check here)
+      if (!emp.dob || !/^\d{4}-\d{2}-\d{2}$/.test(emp.dob)) {
+        errors.push('Date of birth missing or malformed (expected YYYY-MM-DD)');
+      }
+
       return {
         ...emp,
         status: errors.length === 0 ? 'valid' : 'error',
@@ -211,10 +214,10 @@ export default function Phase4Page() {
         setProgressMessage(`Creating ${emp.name}...`);
 
         try {
-          // Parse roles
-          const roles = emp.roles
+          // Parse roles (empRoles to avoid shadowing the `roles` state)
+          const empRoles = emp.roles
             ? emp.roles.split(',').map((r) => {
-                const roleDef = PGR_ROLES.find((pr) => pr.code === r.trim());
+                const roleDef = roles.find((pr) => pr.code === r.trim());
                 return {
                   code: r.trim(),
                   name: roleDef?.name || r.trim(),
@@ -243,10 +246,10 @@ export default function Phase4Page() {
             mobileNumber: emp.mobileNumber,
             emailId: emp.emailId,
             gender: emp.gender,
-            dob: emp.dob ? new Date(emp.dob).getTime() : undefined,
+            dob: new Date(emp.dob).getTime(),
             department: emp.department,
             designation: emp.designation,
-            roles,
+            roles: empRoles,
             jurisdictions,
             dateOfAppointment: emp.dateOfAppointment
               ? new Date(emp.dateOfAppointment).getTime()
@@ -389,7 +392,7 @@ export default function Phase4Page() {
             <ul className="text-xs sm:text-sm text-muted-foreground mt-1 space-y-1">
               <li>• Departments: {departments.length} loaded</li>
               <li>• Designations: {designations.length} loaded</li>
-              <li>• Roles: {PGR_ROLES.length} available</li>
+              <li>• Roles: {roles.length} available</li>
               <li>• Boundaries: {boundaries.length} loaded</li>
             </ul>
           </div>
@@ -428,7 +431,7 @@ export default function Phase4Page() {
             <div className="grid grid-cols-2 gap-2 sm:gap-4 text-xs sm:text-sm mb-3 sm:mb-4">
               <div className="text-success">✓ Departments: {departments.length} loaded</div>
               <div className="text-success">✓ Designations: {designations.length} loaded</div>
-              <div className="text-success">✓ Roles: {PGR_ROLES.length} available</div>
+              <div className="text-success">✓ Roles: {roles.length} available</div>
               <div className="text-success">✓ Boundaries: {boundaries.length} loaded</div>
             </div>
 
@@ -439,6 +442,9 @@ export default function Phase4Page() {
               </li>
               <li>
                 • <strong>mobileNumber</strong> - 10-digit mobile number
+              </li>
+              <li>
+                • <strong>dob</strong> - Date of birth (YYYY-MM-DD)
               </li>
               <li>
                 • <strong>department</strong> - Department code
@@ -525,6 +531,7 @@ export default function Phase4Page() {
                     <TableHead className="text-xs sm:text-sm font-condensed">Status</TableHead>
                     <TableHead className="text-xs sm:text-sm font-condensed">Name</TableHead>
                     <TableHead className="text-xs sm:text-sm font-condensed">Mobile</TableHead>
+                    <TableHead className="text-xs sm:text-sm font-condensed">DOB</TableHead>
                     <TableHead className="text-xs sm:text-sm font-condensed">Dept</TableHead>
                     <TableHead className="text-xs sm:text-sm font-condensed">Designation</TableHead>
                     <TableHead className="text-xs sm:text-sm font-condensed">Roles</TableHead>
@@ -546,6 +553,7 @@ export default function Phase4Page() {
                       </TableCell>
                       <TableCell className="font-medium text-xs sm:text-sm">{emp.name}</TableCell>
                       <TableCell className="font-mono text-xs sm:text-sm">{emp.mobileNumber}</TableCell>
+                      <TableCell className="font-mono text-xs sm:text-sm">{emp.dob}</TableCell>
                       <TableCell className="text-xs sm:text-sm">
                         <span className={emp.status === 'error' ? 'text-destructive' : ''}>
                           {emp.department}

--- a/src/resources/employees/AssignmentEditor.tsx
+++ b/src/resources/employees/AssignmentEditor.tsx
@@ -142,7 +142,17 @@ export function AssignmentEditor({
             const radioName = `${id}-current`;
 
             return (
-              <div key={index} className="border rounded p-3 bg-muted/30">
+              <div key={index} className="relative border rounded p-3 pr-10 bg-muted/30">
+                <button
+                  type="button"
+                  onClick={() => removeRow(index)}
+                  disabled={blockRemove}
+                  aria-label={`Remove assignment ${index + 1}`}
+                  title={blockRemove ? 'Mark another assignment as current first' : undefined}
+                  className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-40 disabled:pointer-events-none"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
                     <Label className="mb-1.5 block text-xs font-medium text-foreground">
@@ -224,7 +234,7 @@ export function AssignmentEditor({
                   </div>
                 </div>
 
-                <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+                <div className="mt-3 flex flex-wrap items-center gap-3">
                   <label className="inline-flex items-center gap-2 text-sm">
                     <input
                       type="radio"
@@ -233,27 +243,15 @@ export function AssignmentEditor({
                       onChange={() => setCurrent(index)}
                       className="h-4 w-4"
                     />
-                    Current assignment
+                    <span className={isCurrent ? 'font-medium text-foreground' : 'text-muted-foreground'}>
+                      Current assignment
+                    </span>
                   </label>
-
-                  <div className="flex flex-col items-end gap-1">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => removeRow(index)}
-                      disabled={blockRemove}
-                      aria-label={`Remove assignment ${index + 1}`}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                      Remove
-                    </Button>
-                    {blockRemove && (
-                      <p className="text-xs text-muted-foreground">
-                        Mark another assignment as current first
-                      </p>
-                    )}
-                  </div>
+                  {blockRemove && (
+                    <span className="text-xs text-muted-foreground">
+                      Mark another current first to remove this row
+                    </span>
+                  )}
                 </div>
               </div>
             );

--- a/src/resources/employees/AssignmentEditor.tsx
+++ b/src/resources/employees/AssignmentEditor.tsx
@@ -1,0 +1,274 @@
+import { useMemo } from 'react';
+import { useInput, useGetList, type RaRecord } from 'ra-core';
+import { Plus, Trash2 } from 'lucide-react';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import type { EmployeeAssignment } from '@/api/types';
+
+export interface AssignmentEditorProps {
+  source?: string;
+  label?: string;
+  help?: string;
+}
+
+interface NamedRecord extends RaRecord {
+  code: string;
+  name?: string;
+}
+
+function toAssignmentRow(entry: unknown): EmployeeAssignment {
+  const r = (entry && typeof entry === 'object' ? entry : {}) as Record<string, unknown>;
+  return {
+    id: typeof r.id === 'string' ? r.id : undefined,
+    position: typeof r.position === 'string' ? r.position : undefined,
+    department: typeof r.department === 'string' ? r.department : '',
+    designation: typeof r.designation === 'string' ? r.designation : '',
+    fromDate: typeof r.fromDate === 'number' ? r.fromDate : Date.now(),
+    toDate: typeof r.toDate === 'number' ? r.toDate : undefined,
+    govtOrderNumber: typeof r.govtOrderNumber === 'string' ? r.govtOrderNumber : undefined,
+    isCurrentAssignment: typeof r.isCurrentAssignment === 'boolean' ? r.isCurrentAssignment : false,
+    isHod: typeof r.isHod === 'boolean' ? r.isHod : undefined,
+  };
+}
+
+function epochToInputDate(epoch: number | undefined): string {
+  if (!epoch || Number.isNaN(epoch)) return '';
+  try {
+    return new Date(epoch).toISOString().slice(0, 10);
+  } catch {
+    return '';
+  }
+}
+
+function inputDateToEpoch(value: string): number | undefined {
+  if (!value) return undefined;
+  const ms = new Date(value).getTime();
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+export function AssignmentEditor({
+  source = 'assignments',
+  label = 'Assignments',
+  help,
+}: AssignmentEditorProps) {
+  const { id, field } = useInput({ source });
+
+  const rows: EmployeeAssignment[] = useMemo(() => {
+    if (!Array.isArray(field.value)) return [];
+    return (field.value as unknown[]).map(toAssignmentRow);
+  }, [field.value]);
+
+  const { data: departments, isLoading: departmentsLoading } = useGetList<NamedRecord>(
+    'departments',
+    { pagination: { page: 1, perPage: 1000 }, sort: { field: 'name', order: 'ASC' } },
+  );
+
+  const { data: designations, isLoading: designationsLoading } = useGetList<NamedRecord>(
+    'designations',
+    { pagination: { page: 1, perPage: 1000 }, sort: { field: 'name', order: 'ASC' } },
+  );
+
+  const writeRows = (next: EmployeeAssignment[]) => {
+    field.onChange(next);
+  };
+
+  const updateRow = (index: number, patch: Partial<EmployeeAssignment>) => {
+    const next = rows.slice();
+    next[index] = { ...next[index], ...patch };
+    writeRows(next);
+  };
+
+  const setCurrent = (index: number) => {
+    const next = rows.map((r, i) => ({
+      ...r,
+      isCurrentAssignment: i === index,
+      ...(i === index ? { toDate: undefined } : {}),
+    }));
+    writeRows(next);
+  };
+
+  const addRow = () => {
+    writeRows([
+      ...rows,
+      {
+        department: '',
+        designation: '',
+        fromDate: Date.now(),
+        isCurrentAssignment: false,
+      },
+    ]);
+  };
+
+  const removeRow = (index: number) => {
+    const next = rows.slice();
+    next.splice(index, 1);
+    writeRows(next);
+  };
+
+  const currentCount = rows.filter((r) => r.isCurrentAssignment).length;
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+        </Label>
+      )}
+
+      {rows.length === 0 ? (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-dashed p-3">
+          <p className="text-sm text-muted-foreground">No assignments added yet</p>
+          <Button type="button" variant="outline" size="sm" onClick={addRow}>
+            <Plus className="w-4 h-4" />
+            Add assignment
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {rows.map((row, index) => {
+            const isCurrent = !!row.isCurrentAssignment;
+            // Block removal of the sole current row until another is marked current.
+            const blockRemove = isCurrent && currentCount <= 1 && rows.length > 1;
+            const fromValue = epochToInputDate(row.fromDate);
+            const toValue = epochToInputDate(row.toDate);
+            const radioName = `${id}-current`;
+
+            return (
+              <div key={index} className="border rounded p-3 bg-muted/30">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <Label className="mb-1.5 block text-xs font-medium text-foreground">
+                      Department
+                    </Label>
+                    <Select
+                      value={row.department ?? ''}
+                      onValueChange={(value) => updateRow(index, { department: value })}
+                      disabled={departmentsLoading}
+                    >
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={
+                            departmentsLoading ? 'Loading...' : 'Select department...'
+                          }
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {(departments ?? []).map((d) => (
+                          <SelectItem key={d.code} value={d.code} data-value={d.code}>
+                            {d.name ?? d.code}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div>
+                    <Label className="mb-1.5 block text-xs font-medium text-foreground">
+                      Designation
+                    </Label>
+                    <Select
+                      value={row.designation ?? ''}
+                      onValueChange={(value) => updateRow(index, { designation: value })}
+                      disabled={designationsLoading}
+                    >
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={
+                            designationsLoading ? 'Loading...' : 'Select designation...'
+                          }
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {(designations ?? []).map((d) => (
+                          <SelectItem key={d.code} value={d.code} data-value={d.code}>
+                            {d.name ?? d.code}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div>
+                    <Label className="mb-1.5 block text-xs font-medium text-foreground">
+                      From Date
+                    </Label>
+                    <Input
+                      type="date"
+                      value={fromValue}
+                      onChange={(e) =>
+                        updateRow(index, { fromDate: inputDateToEpoch(e.target.value) ?? Date.now() })
+                      }
+                    />
+                  </div>
+
+                  <div>
+                    <Label className="mb-1.5 block text-xs font-medium text-foreground">
+                      To Date
+                    </Label>
+                    <Input
+                      type="date"
+                      value={isCurrent ? '' : toValue}
+                      disabled={isCurrent}
+                      onChange={(e) =>
+                        updateRow(index, { toDate: inputDateToEpoch(e.target.value) })
+                      }
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+                  <label className="inline-flex items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name={radioName}
+                      checked={isCurrent}
+                      onChange={() => setCurrent(index)}
+                      className="h-4 w-4"
+                    />
+                    Current assignment
+                  </label>
+
+                  <div className="flex flex-col items-end gap-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => removeRow(index)}
+                      disabled={blockRemove}
+                      aria-label={`Remove assignment ${index + 1}`}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                      Remove
+                    </Button>
+                    {blockRemove && (
+                      <p className="text-xs text-muted-foreground">
+                        Mark another assignment as current first
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+
+          <div>
+            <Button type="button" variant="outline" size="sm" onClick={addRow}>
+              <Plus className="w-4 h-4" />
+              Add assignment
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/src/resources/employees/EmployeeCreate.tsx
+++ b/src/resources/employees/EmployeeCreate.tsx
@@ -1,4 +1,10 @@
 import { DigitCreate, DigitFormCodeInput, DigitFormInput, DigitFormSelect, v } from '@/admin';
+import { FieldSection } from '@/admin/fields';
+import { DEFAULT_PASSWORD } from '@/api/config';
+import { useApp } from '../../App';
+import { RolesEditor } from './RolesEditor';
+import { JurisdictionEditor } from './JurisdictionEditor';
+import { AssignmentEditor } from './AssignmentEditor';
 
 const GENDER_CHOICES = [
   { value: 'MALE', label: 'Male' },
@@ -19,38 +25,135 @@ const TYPE_CHOICES = [
   { value: 'DEPUTATION', label: 'Deputation' },
 ];
 
-const defaults = {
-  employeeType: 'PERMANENT',
-  employeeStatus: 'EMPLOYED',
-  user: { type: 'EMPLOYEE', gender: 'MALE', roles: [{ code: 'EMPLOYEE' }] },
-  jurisdictions: [{ hierarchy: 'ADMIN', boundaryType: 'City', boundary: 'pg' }],
-  assignments: [{ department: 'DEPT_1', designation: 'DESG_1', fromDate: Date.now(), isCurrentAssignment: true }],
-};
+function deriveUsername(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '.')
+    .replace(/\.+/g, '.')
+    .replace(/^\.|\.$/g, '');
+}
+
+function toEpochMs(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value) {
+    const ms = new Date(value).getTime();
+    return Number.isNaN(ms) ? undefined : ms;
+  }
+  return undefined;
+}
 
 export function EmployeeCreate() {
+  const { state } = useApp();
+  const tenantId = state.tenant;
+
+  const defaults = {
+    tenantId,
+    employeeType: 'PERMANENT',
+    employeeStatus: 'EMPLOYED',
+    user: {
+      type: 'EMPLOYEE',
+      active: true,
+      gender: 'MALE',
+      password: DEFAULT_PASSWORD,
+      tenantId,
+      roles: [],
+    },
+    jurisdictions: [],
+    assignments: [],
+  };
+
+  const transform = (data: Record<string, unknown>): Record<string, unknown> => {
+    const userInput = (data.user as Record<string, unknown> | undefined) ?? {};
+    const name = typeof userInput.name === 'string' ? userInput.name.trim() : '';
+    const userName =
+      typeof userInput.userName === 'string' && userInput.userName.trim()
+        ? userInput.userName.trim().toLowerCase()
+        : deriveUsername(name);
+    const user = {
+      ...userInput,
+      userName,
+      tenantId,
+      type: 'EMPLOYEE',
+      active: true,
+      password: typeof userInput.password === 'string' && userInput.password ? userInput.password : DEFAULT_PASSWORD,
+      dob: toEpochMs(userInput.dob),
+    };
+
+    const doa = toEpochMs(data.dateOfAppointment) ?? Date.now();
+
+    return {
+      ...data,
+      tenantId,
+      dateOfAppointment: doa,
+      user,
+    };
+  };
+
   return (
-    <DigitCreate title="Create Employee" record={defaults}>
-      <DigitFormInput source="user.name" label="Name" validate={v.name} />
-      <DigitFormCodeInput source="code" label="Employee Code" deriveFrom="user.name" validate={v.codeRequired} />
-      <DigitFormInput source="user.mobileNumber" label="Mobile Number" validate={v.mobileRequired} />
-      <DigitFormSelect
-        source="user.gender"
-        label="Gender"
-        choices={GENDER_CHOICES}
-        placeholder="Select gender..."
-      />
-      <DigitFormSelect
-        source="employeeStatus"
-        label="Employee Status"
-        choices={STATUS_CHOICES}
-        placeholder="Select status..."
-      />
-      <DigitFormSelect
-        source="employeeType"
-        label="Employee Type"
-        choices={TYPE_CHOICES}
-        placeholder="Select type..."
-      />
+    <DigitCreate title="Create Employee" record={defaults} transform={transform}>
+      <FieldSection title="Employee Info">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <DigitFormInput source="user.name" label="Name" validate={v.name} />
+          <DigitFormCodeInput
+            source="code"
+            label="Employee Code"
+            deriveFrom="user.name"
+            validate={v.codeRequired}
+          />
+          <DigitFormInput
+            source="user.mobileNumber"
+            label="Mobile Number"
+            validate={v.required}
+            help="Digits only"
+          />
+          <DigitFormInput
+            source="user.userName"
+            label="Username"
+            help="Auto-generated from name if left blank"
+          />
+          <DigitFormInput source="user.emailId" label="Email" type="email" validate={v.emailOptional} />
+          <DigitFormInput source="user.dob" label="Date of Birth" type="date" validate={v.required} />
+          <DigitFormSelect
+            source="user.gender"
+            label="Gender"
+            choices={GENDER_CHOICES}
+            placeholder="Select gender..."
+          />
+          <DigitFormInput source="dateOfAppointment" label="Date of Appointment" type="date" />
+          <DigitFormSelect
+            source="employeeStatus"
+            label="Employee Status"
+            choices={STATUS_CHOICES}
+            placeholder="Select status..."
+          />
+          <DigitFormSelect
+            source="employeeType"
+            label="Employee Type"
+            choices={TYPE_CHOICES}
+            placeholder="Select type..."
+          />
+        </div>
+      </FieldSection>
+
+      <FieldSection title="Roles">
+        <RolesEditor tenantId={tenantId} help="Pick one or more. GRO, DGRO, PGR_LME, CSR are typical for PGR." />
+      </FieldSection>
+
+      <FieldSection title="Assignments">
+        <AssignmentEditor help="At least one assignment must be marked current." />
+      </FieldSection>
+
+      <FieldSection title="Jurisdictions">
+        <JurisdictionEditor tenantId={tenantId} help="Areas this employee is responsible for." />
+      </FieldSection>
+
+      <FieldSection title="Account Password">
+        <DigitFormInput
+          source="user.password"
+          label="Initial Password"
+          help="Defaults to eGov@123. Employee should rotate on first login."
+        />
+      </FieldSection>
     </DigitCreate>
   );
 }

--- a/src/resources/employees/EmployeeEdit.tsx
+++ b/src/resources/employees/EmployeeEdit.tsx
@@ -1,5 +1,17 @@
+import { useMemo, useState } from 'react';
+import { useWatch, useFormContext } from 'react-hook-form';
+import { useGetList, useInput, type InputProps } from 'ra-core';
+import { Copy, KeyRound } from 'lucide-react';
 import { DigitEdit, DigitFormInput, DigitFormSelect, v } from '@/admin';
 import { FieldSection } from '@/admin/fields';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { DEFAULT_PASSWORD } from '@/api/config';
+import { useApp } from '../../App';
+import { RolesEditor } from './RolesEditor';
+import { JurisdictionEditor } from './JurisdictionEditor';
+import { AssignmentEditor } from './AssignmentEditor';
 
 const GENDER_CHOICES = [
   { value: 'MALE', label: 'Male' },
@@ -20,93 +32,242 @@ const TYPE_CHOICES = [
   { value: 'DEPUTATION', label: 'Deputation' },
 ];
 
-const HIERARCHY_CHOICES = [
-  { value: 'ADMIN', label: 'Admin' },
-  { value: 'REVENUE', label: 'Revenue' },
-  { value: 'ELECTION', label: 'Election' },
-];
+function toEpochMs(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value) {
+    const ms = new Date(value).getTime();
+    return Number.isNaN(ms) ? undefined : ms;
+  }
+  return undefined;
+}
 
-const BOUNDARY_TYPE_CHOICES = [
-  { value: 'City', label: 'City' },
-  { value: 'Ward', label: 'Ward' },
-  { value: 'Locality', label: 'Locality' },
-  { value: 'Block', label: 'Block' },
-];
+function epochToDateInput(value: unknown): string {
+  const ms = toEpochMs(value);
+  if (ms === undefined) return '';
+  try {
+    return new Date(ms).toISOString().slice(0, 10);
+  } catch {
+    return '';
+  }
+}
+
+interface DateEpochFieldProps extends InputProps {
+  label?: string;
+  help?: string;
+  className?: string;
+}
+
+function DateEpochField({ label, help, className, ...inputProps }: DateEpochFieldProps) {
+  const { id, field, fieldState, isRequired } = useInput(inputProps);
+  const asString = epochToDateInput(field.value);
+  const hasError = fieldState.invalid && fieldState.isTouched;
+  const errorMessage = fieldState.error?.message;
+  return (
+    <div className={className}>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {isRequired && <span className="text-destructive ml-0.5" aria-label="required">*</span>}
+        </Label>
+      )}
+      <Input
+        id={id}
+        type="date"
+        value={asString}
+        onChange={(e) => {
+          const ms = toEpochMs(e.target.value);
+          field.onChange(ms ?? '');
+        }}
+        onBlur={field.onBlur}
+        aria-invalid={hasError || undefined}
+        className={hasError ? 'border-destructive focus-visible:ring-destructive' : ''}
+      />
+      {hasError && errorMessage && (
+        <p className="mt-1 text-xs text-destructive" role="alert">{errorMessage}</p>
+      )}
+      {!hasError && help && (
+        <p className="mt-1 text-xs text-muted-foreground">{help}</p>
+      )}
+    </div>
+  );
+}
+
+function PasswordResetSection() {
+  const pwd = useWatch({ name: 'user.password' }) as string | undefined;
+  const { setValue } = useFormContext();
+  const [copied, setCopied] = useState(false);
+  const [revealed, setRevealed] = useState(false);
+
+  const handleCopy = async () => {
+    if (!pwd) return;
+    try {
+      await navigator.clipboard.writeText(pwd);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const keepExisting = () => {
+    setValue('user.password', '', { shouldDirty: true });
+    setRevealed(false);
+  };
+
+  return (
+    <div className="space-y-3">
+      {!revealed ? (
+        <div className="flex items-center gap-3">
+          <Button type="button" variant="outline" size="sm" onClick={() => setRevealed(true)} className="gap-2">
+            <KeyRound className="w-4 h-4" />
+            Reset password
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            Leave closed to keep the existing password.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <DigitFormInput
+            source="user.password"
+            label="New password"
+            placeholder={DEFAULT_PASSWORD}
+            help="Employee must rotate on next login."
+          />
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={handleCopy} disabled={!pwd} className="gap-1.5">
+              <Copy className="w-3.5 h-3.5" />
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={keepExisting}>
+              Keep existing
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DeactivationReasonSection({ choices }: { choices: { value: string; label: string }[] }) {
+  const status = useWatch({ name: 'employeeStatus' }) as string | undefined;
+  if (status !== 'INACTIVE' && status !== 'RETIRED') return null;
+  return (
+    <FieldSection title="Deactivation">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <DigitFormSelect
+          source="__deactivationReason"
+          label="Reason for deactivation"
+          choices={choices}
+          placeholder="Select a reason..."
+        />
+      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        On save, the employee's <code>isActive</code> flag is flipped off and the reason is appended to their
+        deactivation history.
+      </p>
+    </FieldSection>
+  );
+}
 
 export function EmployeeEdit() {
-  return (
-    <DigitEdit title="Edit Employee">
-      <FieldSection title="Employee Info">
-        <div className="space-y-4">
-          <DigitFormInput source="code" label="Employee Code" disabled />
-          <DigitFormInput source="user.name" label="Name" validate={v.name} />
-          <DigitFormInput source="user.mobileNumber" label="Mobile Number" validate={v.mobileRequired} />
-          <DigitFormSelect
-            source="employeeStatus"
-            label="Status"
-            choices={STATUS_CHOICES}
-            placeholder="Select status..."
-          />
-          <DigitFormSelect
-            source="employeeType"
-            label="Type"
-            choices={TYPE_CHOICES}
-            placeholder="Select type..."
-          />
-        </div>
-      </FieldSection>
+  const { state } = useApp();
+  const tenantId = state.tenant;
 
-      <FieldSection title="User Account">
-        <div className="space-y-4">
+  const { data: reasonsList } = useGetList('deactivation-reasons', {
+    pagination: { page: 1, perPage: 100 },
+    sort: { field: 'code', order: 'ASC' },
+  });
+  const reasonChoices = useMemo(() => {
+    const base = (reasonsList ?? []).map((r) => {
+      const code = String((r as Record<string, unknown>).code ?? r.id);
+      return { value: code, label: code };
+    });
+    if (base.length === 0) {
+      return [
+        { value: 'OTHERS', label: 'Others' },
+        { value: 'RETIRED', label: 'Retired' },
+        { value: 'TERMINATED', label: 'Terminated' },
+        { value: 'RESIGNED', label: 'Resigned' },
+      ];
+    }
+    return base;
+  }, [reasonsList]);
+
+  const transform = (data: Record<string, unknown>): Record<string, unknown> => {
+    const user = { ...((data.user as Record<string, unknown> | undefined) ?? {}) };
+    if (typeof user.password === 'string' && user.password === '') {
+      delete user.password;
+    }
+
+    const status = typeof data.employeeStatus === 'string' ? data.employeeStatus : '';
+    const isInactive = status === 'INACTIVE' || status === 'RETIRED';
+    const reasonCode = typeof data.__deactivationReason === 'string' ? data.__deactivationReason : 'OTHERS';
+    const existingDetails = Array.isArray(data.deactivationDetails) ? data.deactivationDetails : [];
+    const deactivationDetails = isInactive
+      ? [...existingDetails, { reasonForDeactivation: reasonCode, effectiveFrom: Date.now() }]
+      : existingDetails;
+
+    const { __deactivationReason: _dropped, ...rest } = data;
+    void _dropped;
+
+    return {
+      ...rest,
+      tenantId,
+      user,
+      isActive: !isInactive,
+      deactivationDetails,
+    };
+  };
+
+  return (
+    <DigitEdit title="Edit Employee" transform={transform}>
+      <FieldSection title="Employee Info">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <DigitFormInput source="code" label="Employee Code" disabled />
           <DigitFormInput source="user.userName" label="Username" disabled />
+          <DigitFormInput source="user.name" label="Name" validate={v.name} />
+          <DigitFormInput source="user.mobileNumber" label="Mobile Number" validate={v.required} />
+          <DigitFormInput source="user.emailId" label="Email" type="email" validate={v.emailOptional} />
           <DigitFormSelect
             source="user.gender"
             label="Gender"
             choices={GENDER_CHOICES}
             placeholder="Select gender..."
           />
-          <DigitFormInput source="user.emailId" label="Email" validate={v.emailOptional} />
-        </div>
-      </FieldSection>
-
-      <FieldSection title="Current Assignment">
-        <div className="space-y-4">
+          <DateEpochField source="user.dob" label="Date of Birth" />
+          <DateEpochField source="dateOfAppointment" label="Date of Appointment" />
           <DigitFormSelect
-            source="assignments.0.department"
-            label="Department"
-            reference="departments"
-            placeholder="Select department..."
+            source="employeeType"
+            label="Type"
+            choices={TYPE_CHOICES}
+            placeholder="Select type..."
           />
           <DigitFormSelect
-            source="assignments.0.designation"
-            label="Designation"
-            reference="designations"
-            placeholder="Select designation..."
+            source="employeeStatus"
+            label="Status"
+            choices={STATUS_CHOICES}
+            placeholder="Select status..."
           />
         </div>
       </FieldSection>
 
-      <FieldSection title="Jurisdiction">
-        <div className="space-y-4">
-          <DigitFormSelect
-            source="jurisdictions.0.hierarchy"
-            label="Hierarchy"
-            choices={HIERARCHY_CHOICES}
-            placeholder="Select hierarchy..."
-          />
-          <DigitFormSelect
-            source="jurisdictions.0.boundaryType"
-            label="Boundary Type"
-            choices={BOUNDARY_TYPE_CHOICES}
-            placeholder="Select boundary type..."
-          />
-          <DigitFormSelect
-            source="jurisdictions.0.boundary"
-            label="Boundary"
-            reference="boundaries"
-            placeholder="Select boundary..."
-          />
-        </div>
+      <DeactivationReasonSection choices={reasonChoices} />
+
+      <FieldSection title="Roles">
+        <RolesEditor tenantId={tenantId} />
+      </FieldSection>
+
+      <FieldSection title="Assignments">
+        <AssignmentEditor />
+      </FieldSection>
+
+      <FieldSection title="Jurisdictions">
+        <JurisdictionEditor tenantId={tenantId} />
+      </FieldSection>
+
+      <FieldSection title="Account Password">
+        <PasswordResetSection />
       </FieldSection>
     </DigitEdit>
   );

--- a/src/resources/employees/JurisdictionEditor.tsx
+++ b/src/resources/employees/JurisdictionEditor.tsx
@@ -189,7 +189,15 @@ export function JurisdictionEditor({
             const boundaryOptions = getBoundaryOptions(hierarchyType, boundaryType);
 
             return (
-              <div key={index} className="border rounded p-3 bg-muted/30">
+              <div key={index} className="relative border rounded p-3 pr-10 bg-muted/30">
+                <button
+                  type="button"
+                  onClick={() => removeRow(index)}
+                  aria-label={`Remove jurisdiction ${index + 1}`}
+                  className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                   <div>
                     <Label className="mb-1.5 block text-xs font-medium text-foreground">
@@ -270,18 +278,6 @@ export function JurisdictionEditor({
                   </div>
                 </div>
 
-                <div className="mt-2 flex justify-end">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => removeRow(index)}
-                    aria-label={`Remove jurisdiction ${index + 1}`}
-                  >
-                    <Trash2 className="w-4 h-4" />
-                    Remove
-                  </Button>
-                </div>
               </div>
             );
           })}

--- a/src/resources/employees/JurisdictionEditor.tsx
+++ b/src/resources/employees/JurisdictionEditor.tsx
@@ -40,11 +40,16 @@ interface BoundaryRecord extends RaRecord {
 
 function toJurisdictionRow(entry: unknown, tenantId: string): EmployeeJurisdiction {
   const r = (entry && typeof entry === 'object' ? entry : {}) as Record<string, unknown>;
+  // HRMS DTO uses `hierarchy`; MDMS side uses `hierarchyType`. Read either, write both.
+  const hierarchyType =
+    (typeof r.hierarchyType === 'string' && r.hierarchyType) ||
+    (typeof r.hierarchy === 'string' && r.hierarchy) ||
+    '';
   return {
     id: typeof r.id === 'string' ? r.id : undefined,
     boundary: typeof r.boundary === 'string' ? r.boundary : '',
     boundaryType: typeof r.boundaryType === 'string' ? r.boundaryType : '',
-    hierarchyType: typeof r.hierarchyType === 'string' ? r.hierarchyType : '',
+    hierarchyType,
     isActive: typeof r.isActive === 'boolean' ? r.isActive : true,
     ...(typeof r.tenantId === 'string' ? { tenantId: r.tenantId } : { tenantId }),
   } as EmployeeJurisdiction & { tenantId: string };
@@ -121,6 +126,10 @@ export function JurisdictionEditor({
     field.onChange(
       next.map((r) => ({
         ...r,
+        // HRMS's DTO validates `hierarchy` (NotNull). Stamp both field names so
+        // either the legacy or MDMS-aligned reader is satisfied.
+        hierarchy: r.hierarchyType ?? '',
+        hierarchyType: r.hierarchyType ?? '',
         isActive: true,
         tenantId,
       })),

--- a/src/resources/employees/JurisdictionEditor.tsx
+++ b/src/resources/employees/JurisdictionEditor.tsx
@@ -1,0 +1,301 @@
+import { useMemo } from 'react';
+import { useInput, useGetList, type RaRecord } from 'ra-core';
+import { Plus, Trash2 } from 'lucide-react';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import type { EmployeeJurisdiction } from '@/api/types';
+
+export interface JurisdictionEditorProps {
+  source?: string;
+  label?: string;
+  tenantId: string;
+  help?: string;
+}
+
+interface HierarchyLevel {
+  boundaryType: string;
+  parentBoundaryType?: string | null;
+  active?: boolean;
+}
+
+interface HierarchyRecord extends RaRecord {
+  hierarchyType: string;
+  boundaryHierarchy?: HierarchyLevel[];
+}
+
+interface BoundaryRecord extends RaRecord {
+  code: string;
+  name?: string;
+  boundaryType: string;
+  hierarchyType?: string;
+  parentCode?: string;
+}
+
+function toJurisdictionRow(entry: unknown, tenantId: string): EmployeeJurisdiction {
+  const r = (entry && typeof entry === 'object' ? entry : {}) as Record<string, unknown>;
+  return {
+    id: typeof r.id === 'string' ? r.id : undefined,
+    boundary: typeof r.boundary === 'string' ? r.boundary : '',
+    boundaryType: typeof r.boundaryType === 'string' ? r.boundaryType : '',
+    hierarchyType: typeof r.hierarchyType === 'string' ? r.hierarchyType : '',
+    isActive: typeof r.isActive === 'boolean' ? r.isActive : true,
+    ...(typeof r.tenantId === 'string' ? { tenantId: r.tenantId } : { tenantId }),
+  } as EmployeeJurisdiction & { tenantId: string };
+}
+
+export function JurisdictionEditor({
+  source = 'jurisdictions',
+  label = 'Jurisdictions',
+  tenantId,
+  help,
+}: JurisdictionEditorProps) {
+  const { id, field } = useInput({ source });
+
+  const rows: EmployeeJurisdiction[] = useMemo(() => {
+    if (!Array.isArray(field.value)) return [];
+    return (field.value as unknown[]).map((v) => toJurisdictionRow(v, tenantId));
+  }, [field.value, tenantId]);
+
+  const { data: hierarchies, isLoading: hierarchiesLoading } = useGetList<HierarchyRecord>(
+    'boundary-hierarchies',
+    { pagination: { page: 1, perPage: 100 }, sort: { field: 'hierarchyType', order: 'ASC' } },
+  );
+
+  const { data: boundaries, isLoading: boundariesLoading } = useGetList<BoundaryRecord>(
+    'boundaries',
+    { pagination: { page: 1, perPage: 1000 }, sort: { field: 'name', order: 'ASC' } },
+  );
+
+  const hierarchyChoices = useMemo(() => {
+    if (!hierarchies) return [] as { value: string; label: string }[];
+    return hierarchies.map((h) => ({ value: h.hierarchyType, label: h.hierarchyType }));
+  }, [hierarchies]);
+
+  const boundaryTypesByHierarchy = useMemo(() => {
+    const map = new Map<string, string[]>();
+    if (!hierarchies) return map;
+    for (const h of hierarchies) {
+      const levels = Array.isArray(h.boundaryHierarchy) ? h.boundaryHierarchy : [];
+      const types: string[] = [];
+      const seen = new Set<string>();
+      for (const lvl of levels) {
+        if (!lvl || lvl.active === false) continue;
+        const t = lvl.boundaryType;
+        if (!t || seen.has(t)) continue;
+        seen.add(t);
+        types.push(t);
+      }
+      map.set(h.hierarchyType, types);
+    }
+    return map;
+  }, [hierarchies]);
+
+  const boundariesByHierarchyAndType = useMemo(() => {
+    const byHierarchy = new Map<string, Map<string, BoundaryRecord[]>>();
+    const byTypeOnly = new Map<string, BoundaryRecord[]>();
+    if (!boundaries) return { byHierarchy, byTypeOnly };
+    for (const b of boundaries) {
+      if (!b.boundaryType) continue;
+      const listByType = byTypeOnly.get(b.boundaryType) ?? [];
+      listByType.push(b);
+      byTypeOnly.set(b.boundaryType, listByType);
+      if (b.hierarchyType) {
+        const inner = byHierarchy.get(b.hierarchyType) ?? new Map<string, BoundaryRecord[]>();
+        const arr = inner.get(b.boundaryType) ?? [];
+        arr.push(b);
+        inner.set(b.boundaryType, arr);
+        byHierarchy.set(b.hierarchyType, inner);
+      }
+    }
+    return { byHierarchy, byTypeOnly };
+  }, [boundaries]);
+
+  const writeRows = (next: EmployeeJurisdiction[]) => {
+    field.onChange(
+      next.map((r) => ({
+        ...r,
+        isActive: true,
+        tenantId,
+      })),
+    );
+  };
+
+  const updateRow = (index: number, patch: Partial<EmployeeJurisdiction>) => {
+    const next = rows.slice();
+    next[index] = { ...next[index], ...patch } as EmployeeJurisdiction;
+    writeRows(next);
+  };
+
+  const addRow = () => {
+    writeRows([
+      ...rows,
+      {
+        hierarchyType: '',
+        boundaryType: '',
+        boundary: '',
+        isActive: true,
+      } as EmployeeJurisdiction,
+    ]);
+  };
+
+  const removeRow = (index: number) => {
+    const next = rows.slice();
+    next.splice(index, 1);
+    writeRows(next);
+  };
+
+  const getBoundaryOptions = (hierarchyType: string, boundaryType: string): BoundaryRecord[] => {
+    if (!boundaryType) return [];
+    const inner = boundariesByHierarchyAndType.byHierarchy.get(hierarchyType);
+    if (inner && inner.size > 0) {
+      return inner.get(boundaryType) ?? [];
+    }
+    return boundariesByHierarchyAndType.byTypeOnly.get(boundaryType) ?? [];
+  };
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+        </Label>
+      )}
+
+      {rows.length === 0 ? (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-dashed p-3">
+          <p className="text-sm text-muted-foreground">No jurisdictions added yet</p>
+          <Button type="button" variant="outline" size="sm" onClick={addRow}>
+            <Plus className="w-4 h-4" />
+            Add jurisdiction
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {rows.map((row, index) => {
+            const hierarchyType = row.hierarchyType ?? '';
+            const boundaryType = row.boundaryType ?? '';
+            const boundary = row.boundary ?? '';
+
+            const boundaryTypes = hierarchyType
+              ? boundaryTypesByHierarchy.get(hierarchyType) ?? []
+              : [];
+            const boundaryOptions = getBoundaryOptions(hierarchyType, boundaryType);
+
+            return (
+              <div key={index} className="border rounded p-3 bg-muted/30">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                  <div>
+                    <Label className="mb-1.5 block text-xs font-medium text-foreground">
+                      Hierarchy
+                    </Label>
+                    <Select
+                      value={hierarchyType}
+                      onValueChange={(value) =>
+                        updateRow(index, {
+                          hierarchyType: value,
+                          boundaryType: '',
+                          boundary: '',
+                        })
+                      }
+                      disabled={hierarchiesLoading}
+                    >
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={hierarchiesLoading ? 'Loading...' : 'Select hierarchy...'}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {hierarchyChoices.map((c) => (
+                          <SelectItem key={c.value} value={c.value} data-value={c.value}>
+                            {c.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div>
+                    <Label className="mb-1.5 block text-xs font-medium text-foreground">
+                      Boundary Type
+                    </Label>
+                    <Select
+                      value={boundaryType}
+                      onValueChange={(value) =>
+                        updateRow(index, { boundaryType: value, boundary: '' })
+                      }
+                      disabled={!hierarchyType || boundaryTypes.length === 0}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select boundary type..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {boundaryTypes.map((t) => (
+                          <SelectItem key={t} value={t} data-value={t}>
+                            {t}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div>
+                    <Label className="mb-1.5 block text-xs font-medium text-foreground">
+                      Boundary
+                    </Label>
+                    <Select
+                      value={boundary}
+                      onValueChange={(value) => updateRow(index, { boundary: value })}
+                      disabled={!boundaryType || boundariesLoading}
+                    >
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={boundariesLoading ? 'Loading...' : 'Select boundary...'}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {boundaryOptions.map((b) => (
+                          <SelectItem key={b.code} value={b.code} data-value={b.code}>
+                            {b.name ?? b.code}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                <div className="mt-2 flex justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeRow(index)}
+                    aria-label={`Remove jurisdiction ${index + 1}`}
+                  >
+                    <Trash2 className="w-4 h-4" />
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+
+          <div>
+            <Button type="button" variant="outline" size="sm" onClick={addRow}>
+              <Plus className="w-4 h-4" />
+              Add jurisdiction
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/src/resources/employees/RolesEditor.tsx
+++ b/src/resources/employees/RolesEditor.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState, useEffect } from 'react';
 import type { KeyboardEvent } from 'react';
 import { useInput } from 'ra-core';
-import { X } from 'lucide-react';
+import { ChevronDown, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import type { Role } from '@/api/types';
@@ -138,29 +138,36 @@ export function RolesEditor({
         ))}
       </div>
 
-      <Input
-        id={id}
-        type="text"
-        role="combobox"
-        autoComplete="off"
-        aria-expanded={open}
-        aria-controls={listboxId}
-        aria-autocomplete="list"
-        aria-invalid={hasError || undefined}
-        aria-describedby={hasError ? `${id}-error` : undefined}
-        placeholder={isLoading ? 'Loading roles...' : 'Search roles...'}
-        disabled={isLoading}
-        value={query}
-        onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
-        onFocus={() => setOpen(true)}
-        onKeyDown={handleKey}
-        onBlur={field.onBlur}
-        className={hasError ? 'border-destructive focus-visible:ring-destructive' : ''}
-      />
-
-      {isLoading && (
-        <p className="mt-1 text-xs text-muted-foreground">Loading roles...</p>
-      )}
+      <div className="relative">
+        <Input
+          id={id}
+          type="text"
+          role="combobox"
+          autoComplete="off"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-invalid={hasError || undefined}
+          aria-describedby={hasError ? `${id}-error` : undefined}
+          placeholder={isLoading ? 'Loading roles…' : 'Search roles…'}
+          disabled={isLoading}
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={handleKey}
+          onBlur={field.onBlur}
+          className={
+            'pr-8 ' + (hasError ? 'border-destructive focus-visible:ring-destructive' : '')
+          }
+        />
+        <ChevronDown
+          aria-hidden
+          className={
+            'pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground transition-transform ' +
+            (open ? 'rotate-180' : '')
+          }
+        />
+      </div>
 
       {open && !isLoading && (
         <ul

--- a/src/resources/employees/RolesEditor.tsx
+++ b/src/resources/employees/RolesEditor.tsx
@@ -1,0 +1,206 @@
+import { useMemo, useRef, useState, useEffect } from 'react';
+import type { KeyboardEvent } from 'react';
+import { useInput } from 'ra-core';
+import { X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { Role } from '@/api/types';
+import { useRolesLookup } from '@/admin/hrms/useRolesLookup';
+
+export interface RolesEditorProps {
+  source?: string;
+  label?: string;
+  tenantId: string;
+  help?: string;
+}
+
+export function RolesEditor({
+  source = 'user.roles',
+  label = 'Roles',
+  tenantId,
+  help,
+}: RolesEditorProps) {
+  const { id, field, fieldState, isRequired } = useInput({ source });
+  const { roles: available, isLoading, buildRole } = useRolesLookup();
+
+  const value: Role[] = useMemo(() => {
+    if (!Array.isArray(field.value)) return [];
+    const seen = new Set<string>();
+    const out: Role[] = [];
+    for (const entry of field.value as unknown[]) {
+      if (!entry || typeof entry !== 'object') continue;
+      const r = entry as Record<string, unknown>;
+      const code = typeof r.code === 'string' ? r.code : undefined;
+      if (!code || seen.has(code)) continue;
+      seen.add(code);
+      out.push({
+        code,
+        name: typeof r.name === 'string' ? r.name : code,
+        tenantId: typeof r.tenantId === 'string' ? r.tenantId : tenantId,
+      });
+    }
+    return out;
+  }, [field.value, tenantId]);
+
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const listboxId = `${id}-listbox`;
+
+  const selectedCodes = useMemo(() => new Set(value.map((r) => r.code)), [value]);
+
+  const options = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return available
+      .filter((r) => !selectedCodes.has(r.code))
+      .filter((r) => {
+        if (!q) return true;
+        return r.code.toLowerCase().includes(q) || r.name.toLowerCase().includes(q);
+      });
+  }, [available, selectedCodes, query]);
+
+  useEffect(() => {
+    setActiveIdx(0);
+  }, [query, options.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  const addRole = (code: string) => {
+    if (selectedCodes.has(code)) return;
+    const role = buildRole(code, tenantId);
+    field.onChange([...value, role]);
+    setQuery('');
+  };
+
+  const removeRole = (code: string) => {
+    field.onChange(value.filter((r) => r.code !== code));
+  };
+
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setActiveIdx((i) => Math.min(options.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter') {
+      if (options.length > 0 && open) {
+        e.preventDefault();
+        const pick = options[activeIdx] ?? options[0];
+        if (pick) addRole(pick.code);
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    } else if (e.key === 'Backspace' && !query && value.length > 0) {
+      removeRole(value[value.length - 1].code);
+    }
+  };
+
+  const hasError = fieldState.invalid && fieldState.isTouched;
+  const errorMessage = fieldState.error?.message;
+
+  return (
+    <div ref={containerRef} className="relative">
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {isRequired && <span className="text-destructive ml-0.5" aria-label="required">*</span>}
+        </Label>
+      )}
+
+      <div className="flex flex-wrap gap-1.5 mb-1.5" aria-live="polite">
+        {value.map((role) => (
+          <span
+            key={role.code}
+            className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-primary/10 text-primary text-xs font-medium"
+          >
+            <span className="font-semibold">{role.code}</span>
+            <span className="opacity-80">{role.name}</span>
+            <button
+              type="button"
+              onClick={() => removeRole(role.code)}
+              aria-label={`remove ${role.code}`}
+              className="hover:text-destructive"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </span>
+        ))}
+      </div>
+
+      <Input
+        id={id}
+        type="text"
+        role="combobox"
+        autoComplete="off"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-autocomplete="list"
+        aria-invalid={hasError || undefined}
+        aria-describedby={hasError ? `${id}-error` : undefined}
+        placeholder={isLoading ? 'Loading roles...' : 'Search roles...'}
+        disabled={isLoading}
+        value={query}
+        onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKey}
+        onBlur={field.onBlur}
+        className={hasError ? 'border-destructive focus-visible:ring-destructive' : ''}
+      />
+
+      {isLoading && (
+        <p className="mt-1 text-xs text-muted-foreground">Loading roles...</p>
+      )}
+
+      {open && !isLoading && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="absolute z-20 mt-1 max-h-56 w-full overflow-auto rounded-md border border-input bg-popover text-popover-foreground shadow-md"
+        >
+          {options.length === 0 ? (
+            <li className="px-3 py-2 text-xs text-muted-foreground">
+              {available.length === 0 ? 'No roles available' : 'No matches'}
+            </li>
+          ) : (
+            options.map((opt, idx) => (
+              <li
+                key={opt.code}
+                role="option"
+                aria-selected={idx === activeIdx}
+                onMouseDown={(e) => { e.preventDefault(); addRole(opt.code); }}
+                onMouseEnter={() => setActiveIdx(idx)}
+                className={
+                  'cursor-pointer px-3 py-1.5 text-sm ' +
+                  (idx === activeIdx ? 'bg-accent text-accent-foreground' : '')
+                }
+              >
+                <span className="font-medium">{opt.code}</span>
+                <span className="ml-2 text-muted-foreground">{opt.name}</span>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+
+      {hasError && errorMessage && (
+        <p id={`${id}-error`} role="alert" className="mt-1 text-xs text-destructive">
+          {errorMessage}
+        </p>
+      )}
+      {help && !hasError && (
+        <p className="mt-1 text-xs text-muted-foreground">{help}</p>
+      )}
+    </div>
+  );
+}

--- a/src/utils/excelParser.ts
+++ b/src/utils/excelParser.ts
@@ -674,7 +674,7 @@ export function parseEmployeeExcel(workbook: XLSX.WorkBook): {
     const mobileNumber = String(row['mobileNumber'] || row['MobileNumber'] || row['mobile'] || row['phone'] || '').trim();
     const emailId = String(row['emailId'] || row['EmailId'] || row['email'] || '').trim() || undefined;
     const gender = String(row['gender'] || row['Gender'] || '').trim() || undefined;
-    const dob = String(row['dob'] || row['DOB'] || row['dateOfBirth'] || '').trim() || undefined;
+    const dobRaw = row['dob'] ?? row['DOB'] ?? row['dateOfBirth'];
     const department = String(row['department'] || row['Department'] || '').trim();
     const designation = String(row['designation'] || row['Designation'] || '').trim();
     const roles = String(row['roles'] || row['Roles'] || row['role'] || 'EMPLOYEE').trim();
@@ -748,6 +748,72 @@ export function parseEmployeeExcel(workbook: XLSX.WorkBook): {
       });
       return;
     }
+
+    if (dobRaw === undefined || dobRaw === null || dobRaw === '') {
+      errors.push({
+        row: index + 2,
+        field: 'dob',
+        message: 'Date of birth is required (YYYY-MM-DD)',
+        code: 'REQUIRED_FIELD',
+      });
+      return;
+    }
+
+    let dobYear: number;
+    let dobMonth: number;
+    let dobDay: number;
+
+    if (dobRaw instanceof Date) {
+      dobYear = dobRaw.getUTCFullYear();
+      dobMonth = dobRaw.getUTCMonth() + 1;
+      dobDay = dobRaw.getUTCDate();
+    } else if (typeof dobRaw === 'number') {
+      // Excel epoch adjustment to JS epoch ms: (serial - 25569) * 86400 * 1000.
+      const jsDate = new Date((dobRaw - 25569) * 86400 * 1000);
+      if (Number.isNaN(jsDate.getTime())) {
+        errors.push({
+          row: index + 2,
+          field: 'dob',
+          value: String(dobRaw),
+          message: 'Date of birth is not a valid Excel date serial',
+          code: 'INVALID_FORMAT',
+        });
+        return;
+      }
+      dobYear = jsDate.getUTCFullYear();
+      dobMonth = jsDate.getUTCMonth() + 1;
+      dobDay = jsDate.getUTCDate();
+    } else {
+      const dobStr = String(dobRaw).trim();
+      const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dobStr);
+      if (!match) {
+        errors.push({
+          row: index + 2,
+          field: 'dob',
+          value: dobStr,
+          message: 'Date of birth must be ISO format YYYY-MM-DD',
+          code: 'INVALID_FORMAT',
+        });
+        return;
+      }
+      dobYear = Number(match[1]);
+      dobMonth = Number(match[2]);
+      dobDay = Number(match[3]);
+    }
+
+    const maxYear = new Date().getFullYear() - 18;
+    if (dobYear < 1920 || dobYear > maxYear) {
+      errors.push({
+        row: index + 2,
+        field: 'dob',
+        value: `${dobYear}-${String(dobMonth).padStart(2, '0')}-${String(dobDay).padStart(2, '0')}`,
+        message: `Date of birth year must be between 1920 and ${maxYear} (employee must be at least 18)`,
+        code: 'INVALID_FORMAT',
+      });
+      return;
+    }
+
+    const dob = `${dobYear}-${String(dobMonth).padStart(2, '0')}-${String(dobDay).padStart(2, '0')}`;
 
     if (!jurisdictions) {
       warnings.push({


### PR DESCRIPTION
Closes #2.

## Summary

Rebuilds the HRMS employee management surface in the configurator so a single record can be created, edited, and deactivated from `/manage/employees` with full coverage of boundary / jurisdiction, roles, DOB / DOA, password reset, and deactivation reason — without SMS OTP (fixed `eGov@123` default, rotate on first login).

Four commits, each independently shippable:

| SHA | Scope |
|---|---|
| `c7a2077` | `hrms` service: require DOB, add username/mobile uniqueness pre-flights, drop hardcoded `PGR_ROLES` |
| `f6f27bd` | Phase 4 bulk onboarding: require `dob` Excel column, load roles from MDMS (`ACCESSCONTROL-ROLES.roles`) |
| `10e316f` | `/manage/employees`: full-coverage Create + Edit with `RolesEditor`, `JurisdictionEditor`, `AssignmentEditor`, `DateEpochField`, deactivation + password reset |
| `3422f8a` | Polish: compact icon-only row controls, combobox caret |

Detailed execution doc lives at `Nai Pepea/HRMS-EXPANSION-PLAN.md` in the egov working tree.

## What's new

**Shared editors** (`src/resources/employees/`)
- `RolesEditor` — combobox + chip array, backed by new `useRolesLookup` hook that reads from the `access-roles` resource. No more hardcoded 5-role list; DGRO / CSR now work.
- `JurisdictionEditor` — multi-row, cascading `hierarchy → boundaryType → boundary`. Hierarchy + boundaryType come from `boundary-hierarchies`; boundaries are indexed by hierarchyType with a type-only fallback.
- `AssignmentEditor` — multi-row with dept + designation (reference selects), from / to dates (epoch ms), and a `isCurrentAssignment` radio that flips siblings client-side.

**`EmployeeCreate` rewritten**
- No more `DEPT_1 / DESG_1 / pg / EMPLOYEE` defaults (the `pg` leftover was silently breaking records under `ke.nairobi`).
- Session tenant pulled from `useApp()`; `user.tenantId`, `type`, `active`, `password` stamped via a new `transform` prop on `DigitCreate`.
- Password section surfaces the default `eGov@123` explicitly with a "rotate on first login" note.

**`EmployeeEdit` expanded**
- All fields editable except `code` and `userName`.
- New `DateEpochField` handles the epoch ↔ `YYYY-MM-DD` conversion that HTML `<input type=\"date\">` doesn't.
- `PasswordResetSection` — collapsible, with Copy + Keep existing. Empty password is stripped in `transform` so the server keeps the existing hash.
- Conditional `Deactivation` section appears when status flips to `INACTIVE` / `RETIRED`. Reasons come from the `deactivation-reasons` MDMS resource with a safe fallback. Save appends to `deactivationDetails` and flips `isActive` off.

**Scaffolding**
- `DigitCreate` / `DigitEdit` now expose `transform` so resource UIs can stamp server-required nested fields at submit time.

## Clash analysis

Verified against `upstream/main` and `upstream/feat/theme-editor-ui` on 2026-04-22.
- `feat/theme-editor-ui` touches `MdmsResourceEdit.tsx` + schema descriptors + new files under `src/admin/themeEditor/`. **Zero file overlap.**
- The planned MDMS-visibility work (`Nai Pepea/MDMS-VISIBILITY-PLAN.md`) targets `MdmsResource{Edit,Page,Show}.tsx`, schema catalog, `resourceRegistry.ts`, adds `schemaValidator.ts`. None of the employee files; `resourceRegistry.ts` is only read here.
- Schema descriptors apply to `type: 'mdms'` resources only. Employees are `type: 'hrms'`. No collision.

## Testing plan

### A. `/manage/employees` — single-employee Create

Prerequisite: logged in as `ADMIN` on `ke.nairobi`, management mode.

- [ ] Navigate to `/configurator/manage/employees` → list renders existing 40 pilot employees.
- [ ] Click **Create** → form renders all sections (Info, Roles, Assignments, Jurisdictions, Password).
- [ ] **Code auto-derive**: type a Name → click the wand on Employee Code → code populates in upper-snake.
- [ ] **Username auto-derive**: leave Username blank → save → verify stored `user.userName` = lowercase dotted form of the name.
- [ ] **DOB required**: leave DOB empty, hit Save → red error under the field, form does not submit.
- [ ] **Roles editor**:
  - [ ] Click the search box → caret rotates, dropdown opens.
  - [ ] Type `gro` → dropdown filters to `GRO`, `DGRO`.
  - [ ] Arrow-down + Enter → chip added.
  - [ ] Backspace in empty search → last chip removed.
  - [ ] Click × on a chip → chip removed.
- [ ] **Jurisdiction editor**:
  - [ ] Empty state shows *No jurisdictions added yet* + single Add button.
  - [ ] Click Add → row with three selects. Hierarchy populated from `boundary-hierarchies`.
  - [ ] Pick a hierarchy → boundaryType dropdown becomes enabled, options match the hierarchy's levels.
  - [ ] Pick a boundaryType → boundary dropdown enabled, options filtered to that type.
  - [ ] Add a second jurisdiction row → both persist.
  - [ ] Top-right trash icon on a row → row removed.
- [ ] **Assignment editor**:
  - [ ] Add two rows, mark the second as *Current* → first row's radio flips to unchecked.
  - [ ] Current row's *Current assignment* label renders in foreground weight; the other in muted.
  - [ ] Try to remove the only current row (with ≥ 2 rows) → Remove icon disabled, tooltip shows \"Mark another assignment as current first\", and inline hint appears next to the radio.
- [ ] **Password**: default field shows `eGov@123`. Override to `Naip3p3a!` for the test.
- [ ] Save → employee lands in HRMS. Verify via server:
  ```bash
  curl -sS \"https://naipepea.digit.org/egov-hrms/employees/_search?tenantId=ke.nairobi&codes=TEST_EMP\" \\
    -H \"Authorization: Bearer $TOKEN\" -d '{\"RequestInfo\":{\"apiId\":\"Rainmaker\"}}' | jq '.Employees[0]'
  ```
  Confirm `user.tenantId = \"ke.nairobi\"`, `user.type = \"EMPLOYEE\"`, `user.active = true`, `jurisdictions[].tenantId` stamped, `assignments[0].isCurrentAssignment = true`.
- [ ] Log out, log back in as the new employee with `Naip3p3a!` → login succeeds.

### B. Uniqueness pre-flights

- [ ] Create an employee with mobile `0712345678`.
- [ ] Try to create a second with the same mobile → form save fails with `Mobile \"0712345678\" already exists on tenant ke.nairobi`. Network tab: no `_create` call fired.
- [ ] Same for `userName` collision.
- [ ] Disconnect the network briefly during the pre-flight (Chrome devtools throttling → offline) → verify save falls through (assume-available fallback) instead of hanging.

### C. `/manage/employees/<id>` — Edit round-trip

- [ ] Open the employee created in step A.
- [ ] **DOB / DOA**: both date inputs render the correct date (epoch → `YYYY-MM-DD` conversion). Change DOB by one day, save, re-open → change persisted.
- [ ] **Roles**: remove `GRO`, add `DGRO` → save → re-open → chips correct.
- [ ] **Assignment**: add a second assignment, mark it current → save → re-open → new row persisted as current, old row has `isCurrentAssignment=false`.
- [ ] **Jurisdiction**: add a second jurisdiction covering a different ward → save → re-open → both present.
- [ ] **Password reset**:
  - [ ] Click *Reset password* → section expands with `New password` input.
  - [ ] Type `Rotate@First`, click *Copy* → clipboard contains `Rotate@First`.
  - [ ] Save → re-login as the employee with the new password → succeeds.
  - [ ] Open Edit again, leave the password section closed → save → existing password preserved (verified by re-login).
- [ ] **Deactivation**:
  - [ ] Change Status to `INACTIVE` → Deactivation section appears with reason select.
  - [ ] Select reason `TERMINATED` (or any option from MDMS), save → employee disappears from the default list (filter = EMPLOYED).
  - [ ] Re-open → `isActive = false`, `deactivationDetails` contains a new entry with `reasonForDeactivation = TERMINATED` and a fresh `effectiveFrom`.
  - [ ] Flip status back to `EMPLOYED`, save → `isActive = true` again; historical deactivationDetails entries preserved.

### D. Phase 4 bulk onboarding

Using a small fixture XLSX with 5 rows:

- [ ] Generate-template landing page lists `dob - Date of birth (YYYY-MM-DD)` in required columns.
- [ ] Reference data loading: open devtools → verify four MDMS/boundary calls fire (`departments`, `designations`, `boundaries`, **`ACCESSCONTROL-ROLES.roles`**). The last one is new in this PR; before it was hardcoded.
- [ ] Upload a fixture with:
  - Row 1: all fields valid.
  - Row 2: missing DOB.
  - Row 3: DOB `1990-13-45` (malformed).
  - Row 4: DOB `2020-01-01` (under 18).
  - Row 5: role `FAKE_ROLE` not in MDMS.
- [ ] Preview table shows `DOB` column between Mobile and Dept.
- [ ] Rows 2–5 flagged with red `Error` badge + specific messages; row 1 green.
- [ ] Click *Create N Employees* → only row 1 POSTed.
- [ ] Creating-progress table shows row 1 Created, others Skipped.
- [ ] Completion banner shows `1 created, 0 failed, 4 skipped`.

### E. Regression + build

- [ ] `cd packages/data-provider && npm run build` → clean.
- [ ] `npx vite build --base=/configurator/` → emits `dist/assets/index-*.js` (~2.1 MB, ~672 kB gzipped).
- [ ] `npx tsc --noEmit -p tsconfig.app.json` → no new errors in files touched by this PR.
- [ ] Existing `e2e-onboarding/onboarding.spec.ts` still green (the spec exercises Phase 4 end-to-end with a fixture).
- [ ] Cherry-rebase `feat/theme-editor-ui` on top of this branch → no conflicts (verified via `git merge-tree`).

### F. Deploy on naipepea

```bash
ssh naipepea
cd /opt/egov/digit-configurator
git pull origin main
cd packages/data-provider && npm run build && cd -
npx vite build --base=/configurator/
ts=$(date -u +%Y%m%d-%H%M%S)
cp -r /var/www/configurator /var/www/configurator.bak-${ts}
rsync -a --delete dist/ /var/www/configurator/
curl -sS https://naipepea.digit.org/configurator/ | grep -oE 'index-[A-Za-z0-9_-]+\.(js|css)'
```

Smoke after deploy:
- [ ] Hit `https://naipepea.digit.org/configurator/manage/employees/create` → form renders with all sections.
- [ ] Create a real employee end-to-end (see §A).

## Out of scope (tracked separately)

- Bulk edit / bulk deactivate UI.
- Employee photos / attachments.
- Atomic \"transfer\" workflow across assignments.
- Forced password rotation at first login (needs user-service config, not a configurator change).
- NCCG SSO / Huduma Namba integration.
- Playwright specs in `digit-integration-tests` — separate repo, will land as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added role management editor with searchable multi-select interface for employee role assignment
* Added assignment editor for managing employee work assignments with date ranges and current assignment tracking
* Added jurisdiction editor for managing employee jurisdictions across hierarchies and boundaries
* Added email field support for user accounts
* Added password reset functionality with clipboard copy option
* Added deactivation reason tracking for inactive or retired employees
* Enhanced date-of-birth field with validation for age requirements (minimum 18 years)
* Added username and mobile number uniqueness checks during employee creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->