### PR TITLE
feat(theme-editor): flagship ThemeConfigEditor with live mini-DIGIT preview

### DIFF
--- a/src/admin/MdmsResourceEdit.tsx
+++ b/src/admin/MdmsResourceEdit.tsx
@@ -4,6 +4,7 @@ import { WidgetForFieldSpec } from './widgets';
 import { useEditContext, useResourceContext } from 'ra-core';
 import { getResourceConfig, getResourceLabel } from '@/providers/bridge';
 import { getDescriptor } from './schemaDescriptors';
+import { customEditors } from './themeEditor';
 
 function MdmsEditFields() {
   const resource = useResourceContext() ?? '';
@@ -58,7 +59,19 @@ function MdmsEditFields() {
 
 export function MdmsResourceEdit() {
   const resource = useResourceContext() ?? '';
+  const config = getResourceConfig(resource);
+  const descriptor = getDescriptor(config?.schema);
   const label = getResourceLabel(resource);
+
+  // Escape hatch: if the descriptor names a custom editor, mount that instead.
+  if (descriptor?.customEditor) {
+    const Editor = customEditors[descriptor.customEditor];
+    if (Editor) return <Editor />;
+    // Fall through to the generic form if the key is missing — dev warning.
+    // eslint-disable-next-line no-console
+    console.warn(`[descriptor] customEditor "${descriptor.customEditor}" not registered for schema ${config?.schema}; falling back to generic form.`);
+  }
+
   return (
     <DigitEdit title={`Edit ${label}`}>
       <MdmsEditFields />

--- a/src/admin/schemaDescriptors/theme-config.ts
+++ b/src/admin/schemaDescriptors/theme-config.ts
@@ -16,6 +16,7 @@ import type { SchemaDescriptor } from './types';
  */
 export const themeConfigDescriptor: SchemaDescriptor = {
   schema: 'common-masters.ThemeConfig',
+  customEditor: 'theme-config',
   groups: [
     { title: 'Identity', fields: ['code', 'name', 'version'] },
     { title: 'Primary / Link', fields: [

--- a/src/admin/schemaDescriptors/types.ts
+++ b/src/admin/schemaDescriptors/types.ts
@@ -47,4 +47,9 @@ export interface SchemaDescriptor {
   schema: string;
   groups?: FieldGroup[];
   fields: FieldSpec[];
+  /** Opt into a dedicated custom editor (registered in src/admin/themeEditor/
+   *  or similar). When set, MdmsResourceEdit skips the generic form entirely
+   *  and mounts the registered component instead. String key (not a component
+   *  reference) keeps descriptors serializable and avoids circular imports. */
+  customEditor?: string;
 }

--- a/src/admin/themeEditor/ThemeConfigEditor.tsx
+++ b/src/admin/themeEditor/ThemeConfigEditor.tsx
@@ -1,0 +1,116 @@
+import { useMemo, type ReactNode } from 'react';
+import { useEditContext, useResourceContext } from 'ra-core';
+import { DigitEdit } from '../DigitEdit';
+import { DigitFormInput } from '../DigitFormInput';
+import { ColorInput } from '../widgets/ColorInput';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { getDescriptor } from '../schemaDescriptors';
+import type { FieldGroup, FieldSpec } from '../schemaDescriptors/types';
+import { getResourceLabel } from '@/providers/bridge';
+import { ThemePreview } from './ThemePreview';
+import { HoverContext, useCreateHoverContext, useHoverContext } from './hoverContext';
+
+const SCHEMA = 'common-masters.ThemeConfig';
+
+/** Wraps a ColorInput in mouse/focus handlers so the preview can light up
+ *  whichever elements use this token. */
+function HoveredColorField({ spec }: { spec: FieldSpec }) {
+  const hover = useHoverContext();
+  const enter = () => hover?.setHoveredToken(spec.path);
+  const leave = () => hover?.setHoveredToken(null);
+  return (
+    <div onMouseEnter={enter} onMouseLeave={leave} onFocusCapture={enter} onBlurCapture={leave}>
+      <ColorInput
+        source={spec.path}
+        label={spec.label ?? spec.path.split('.').pop()}
+        help={spec.help}
+      />
+    </div>
+  );
+}
+
+function EditorBody() {
+  const descriptor = getDescriptor(SCHEMA);
+  const { record, isPending } = useEditContext();
+  const hoverValue = useCreateHoverContext();
+
+  const tabs = useMemo<FieldGroup[]>(() => {
+    if (!descriptor?.groups) return [];
+    return descriptor.groups.filter((g) => g.title !== 'Identity');
+  }, [descriptor]);
+
+  const identityFields = useMemo<FieldSpec[]>(() => {
+    if (!descriptor) return [];
+    const identityGroup = descriptor.groups?.find((g) => g.title === 'Identity');
+    const paths = new Set(identityGroup?.fields ?? []);
+    return descriptor.fields.filter((f) => paths.has(f.path));
+  }, [descriptor]);
+
+  if (isPending || !record) return null;
+
+  return (
+    <HoverContext.Provider value={hoverValue}>
+      {/* Identity strip */}
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-3 pb-3 mb-4 border-b border-border">
+        {identityFields.map((spec) => (
+          <DigitFormInput
+            key={spec.path}
+            source={spec.path}
+            label={spec.label ?? spec.path}
+            help={spec.help}
+            type="text"
+          />
+        ))}
+      </section>
+
+      {/* Two-column: form + preview */}
+      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_480px] gap-6">
+        <div className="min-w-0">
+          <Tabs defaultValue={tabs[0]?.title ?? ''} className="w-full">
+            <TabsList className="flex flex-wrap h-auto gap-1 p-1 w-full justify-start">
+              {tabs.map((g) => (
+                <TabsTrigger key={g.title} value={g.title} className="text-xs">
+                  {g.title}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            {tabs.map((g) => (
+              <TabsContent key={g.title} value={g.title} className="mt-3">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  {renderGroupFields(g, descriptor?.fields ?? [])}
+                </div>
+              </TabsContent>
+            ))}
+          </Tabs>
+        </div>
+
+        <aside className="xl:sticky xl:top-4 self-start">
+          <div className="text-xs font-medium text-muted-foreground mb-2">Live preview</div>
+          <ThemePreview />
+          <p className="text-[11px] text-muted-foreground mt-2 leading-snug">
+            Hover a color on the left — the elements that use it light up here. Edit to see the change live.
+          </p>
+        </aside>
+      </div>
+    </HoverContext.Provider>
+  );
+}
+
+function renderGroupFields(group: FieldGroup, allFields: FieldSpec[]): ReactNode {
+  const byPath = new Map(allFields.map((f) => [f.path, f]));
+  return group.fields.map((path) => {
+    const spec = byPath.get(path);
+    if (!spec) return null;
+    return <HoveredColorField key={path} spec={spec} />;
+  });
+}
+
+export function ThemeConfigEditor() {
+  const resource = useResourceContext() ?? '';
+  const label = getResourceLabel(resource);
+  return (
+    <DigitEdit title={`Edit ${label}`}>
+      <EditorBody />
+    </DigitEdit>
+  );
+}

--- a/src/admin/themeEditor/ThemePreview.tsx
+++ b/src/admin/themeEditor/ThemePreview.tsx
@@ -1,0 +1,303 @@
+import { useMemo, type CSSProperties } from 'react';
+import { useWatch } from 'react-hook-form';
+import { useHoverContext } from './hoverContext';
+
+/** Flatten a nested record (tolerant of undefined) into a dotted map, e.g.
+ *  { primary: { main: '#006B3F' } }  ->  { 'primary.main': '#006B3F' }. */
+function flatten(obj: unknown, prefix = ''): Record<string, string> {
+  if (!obj || typeof obj !== 'object') return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === 'object') {
+      Object.assign(out, flatten(v, key));
+    } else if (typeof v === 'string') {
+      out[key] = v;
+    }
+  }
+  return out;
+}
+
+/** Token helper: read `colors.<path>` with a safe default for empty cells. */
+function tk(flat: Record<string, string>, path: string, fallback: string): string {
+  return flat[path] || fallback;
+}
+
+/**
+ * Mini-DIGIT preview: header + sidenav + card with heading, body, link,
+ * buttons, 5-series bar chart, mini table, info/error/success alerts,
+ * disabled input and disabled button. Every visual element carries
+ * `data-token="colors.foo.bar"` (space-separated when multiple tokens
+ * apply) so the hover highlight can light it up when the matching field
+ * in the form is hovered.
+ *
+ * The component subscribes to `colors.*` via useWatch — a single watcher
+ * at the preview root — so form-level keystrokes on individual ColorInputs
+ * don't re-render the form, only this widget.
+ */
+export function ThemePreview() {
+  const colors = useWatch({ name: 'colors' });
+  const hover = useHoverContext();
+
+  const flat = useMemo(() => flatten(colors), [colors]);
+
+  // Chart bars — heights are hard-coded; colors come from chart-1..5.
+  const chart = [
+    { h: 72, token: 'colors.digitv2.chart-1' },
+    { h: 48, token: 'colors.digitv2.chart-2' },
+    { h: 92, token: 'colors.digitv2.chart-3' },
+    { h: 36, token: 'colors.digitv2.chart-4' },
+    { h: 60, token: 'colors.digitv2.chart-5' },
+  ];
+
+  const root: CSSProperties = {
+    backgroundColor: tk(flat, 'grey.light', '#F5F5F5'),
+    color: tk(flat, 'text.primary', '#0B0C0C'),
+    borderColor: tk(flat, 'border', '#D6D5D4'),
+  };
+
+  return (
+    <div
+      ref={hover?.previewRootRef}
+      className="theme-preview rounded-md border overflow-hidden text-xs select-none"
+      style={root}
+      data-token="colors.grey.light colors.text.primary colors.border"
+    >
+      <style>{`
+        .theme-preview .${'theme-token-hover'} {
+          outline: 2px solid #1e90ff;
+          outline-offset: 1px;
+          border-radius: 2px;
+          transition: outline 0.08s ease-out;
+        }
+      `}</style>
+
+      {/* Header bar */}
+      <div
+        className="h-9 flex items-center px-3 gap-3"
+        style={{ backgroundColor: tk(flat, 'digitv2.header-sidenav', '#006B3F'), color: '#FFF' }}
+        data-token="colors.digitv2.header-sidenav"
+      >
+        <span className="font-bold">DIGIT</span>
+        <span className="text-[11px] opacity-80">Dashboard</span>
+        <div className="ml-auto flex gap-2 opacity-80">
+          <span>[user]</span>
+          <span>*</span>
+        </div>
+      </div>
+
+      <div className="flex">
+        {/* Sidebar */}
+        <div
+          className="w-20 py-2 space-y-0.5"
+          style={{ backgroundColor: tk(flat, 'digitv2.header-sidenav', '#006B3F') }}
+          data-token="colors.digitv2.header-sidenav"
+        >
+          <div className="px-2 py-1 text-[10px]" style={{ color: tk(flat, 'secondary', '#FFF') }} data-token="colors.secondary">
+            Menu
+          </div>
+          <div
+            className="mx-1 px-2 py-1 text-[10px] rounded"
+            style={{ backgroundColor: tk(flat, 'primary.selected-bg', '#E6F2EC'), color: tk(flat, 'primary.main', '#006B3F') }}
+            data-token="colors.primary.selected-bg colors.primary.main"
+          >
+            Home
+          </div>
+          <div className="px-3 py-1 text-[10px] opacity-80" style={{ color: '#FFF' }}>Reports</div>
+          <div className="px-3 py-1 text-[10px] opacity-80" style={{ color: '#FFF' }}>Forms</div>
+        </div>
+
+        {/* Main content */}
+        <div className="flex-1 p-2.5 space-y-2">
+          <div
+            className="font-bold text-sm"
+            style={{ color: tk(flat, 'text.heading', '#1A1A2E') }}
+            data-token="colors.text.heading"
+          >
+            Dashboard
+          </div>
+          <div
+            className="text-[10px]"
+            style={{ color: tk(flat, 'text.muted', '#6B7280') }}
+            data-token="colors.text.muted"
+          >
+            Overview of recent activity
+          </div>
+
+          {/* Card */}
+          <div
+            className="rounded border p-2 space-y-1.5"
+            style={{
+              backgroundColor: tk(flat, 'grey.bg', '#FFFFFF'),
+              borderColor: tk(flat, 'border', '#D6D5D4'),
+            }}
+            data-token="colors.grey.bg colors.border"
+          >
+            <div style={{ color: tk(flat, 'text.heading', '#1A1A2E') }} data-token="colors.text.heading" className="font-semibold text-[11px]">
+              Card title
+            </div>
+            <p style={{ color: tk(flat, 'text.secondary', '#505A5F') }} data-token="colors.text.secondary" className="text-[10px] leading-tight">
+              Body paragraph with a{' '}
+              <a
+                href="#"
+                onClick={(e) => e.preventDefault()}
+                style={{ color: tk(flat, 'link.normal', '#006B3F') }}
+                data-token="colors.link.normal colors.link.hover"
+                className="underline hover:opacity-75"
+              >
+                link
+              </a>{' '}
+              here.
+            </p>
+
+            {/* Buttons */}
+            <div className="flex gap-1.5">
+              <button
+                type="button"
+                className="text-[10px] font-medium px-2 py-1 rounded text-white"
+                style={{ backgroundColor: tk(flat, 'primary.main', '#006B3F') }}
+                data-token="colors.primary.main colors.primary.dark"
+              >
+                Primary
+              </button>
+              <button
+                type="button"
+                className="text-[10px] font-medium px-2 py-1 rounded text-white"
+                style={{ backgroundColor: tk(flat, 'primary.accent', '#BB0000') }}
+                data-token="colors.primary.accent"
+              >
+                Secondary
+              </button>
+            </div>
+
+            {/* Chart */}
+            <div
+              className="flex items-end gap-1 h-16 pt-1 border-t"
+              style={{ borderColor: tk(flat, 'grey.mid', '#EEEEEE') }}
+              data-token="colors.grey.mid"
+            >
+              {chart.map((b) => (
+                <div
+                  key={b.token}
+                  className="flex-1 rounded-t"
+                  style={{ height: `${b.h}%`, backgroundColor: tk(flat, b.token.replace('colors.', ''), '#888') }}
+                  data-token={b.token}
+                />
+              ))}
+            </div>
+
+            {/* Table */}
+            <div className="space-y-0">
+              <div
+                className="text-[9px] uppercase tracking-wide px-1 py-0.5"
+                style={{ color: tk(flat, 'text.muted', '#6B7280') }}
+                data-token="colors.text.muted"
+              >
+                Row
+              </div>
+              <div
+                className="text-[10px] px-1 py-0.5 border-t"
+                style={{ borderColor: tk(flat, 'border', '#D6D5D4'), backgroundColor: tk(flat, 'grey.lighter', '#F0F0F0') }}
+                data-token="colors.grey.lighter colors.border"
+              >
+                Row A
+              </div>
+              <div
+                className="text-[10px] px-1 py-0.5 border-t"
+                style={{
+                  borderColor: tk(flat, 'border', '#D6D5D4'),
+                  backgroundColor: tk(flat, 'digitv2.primary-bg', '#E6F2EC'),
+                  color: tk(flat, 'primary.main', '#006B3F'),
+                }}
+                data-token="colors.digitv2.primary-bg colors.primary.light"
+              >
+                Row B (selected)
+              </div>
+              <div
+                className="text-[10px] px-1 py-0.5 border-t"
+                style={{ borderColor: tk(flat, 'border', '#D6D5D4') }}
+                data-token="colors.border"
+              >
+                Row C
+              </div>
+            </div>
+          </div>
+
+          {/* Alerts */}
+          <div className="space-y-1">
+            <div
+              className="px-2 py-1 text-[10px] rounded border-l-2"
+              style={{
+                backgroundColor: tk(flat, 'digitv2.alert-info-bg', '#C7E0F1'),
+                borderLeftColor: tk(flat, 'digitv2.alert-info', '#3498DB'),
+                color: tk(flat, 'info-dark', '#0057BD'),
+              }}
+              data-token="colors.digitv2.alert-info-bg colors.digitv2.alert-info colors.info-dark"
+            >
+              i  Info alert
+            </div>
+            <div
+              className="px-2 py-1 text-[10px] rounded border-l-2"
+              style={{
+                backgroundColor: tk(flat, 'digitv2.alert-error-bg', '#F5CCCC'),
+                borderLeftColor: tk(flat, 'error', '#BB0000'),
+                color: tk(flat, 'error-dark', '#8B0000'),
+              }}
+              data-token="colors.digitv2.alert-error-bg colors.error colors.error-dark"
+            >
+              !  Error alert
+            </div>
+            <div
+              className="px-2 py-1 text-[10px] rounded border-l-2"
+              style={{
+                backgroundColor: tk(flat, 'digitv2.alert-success-bg', '#BAD6C9'),
+                borderLeftColor: tk(flat, 'success', '#006B3F'),
+                color: tk(flat, 'success', '#006B3F'),
+              }}
+              data-token="colors.digitv2.alert-success-bg colors.success"
+            >
+              ✓  Success alert
+            </div>
+            <div
+              className="px-2 py-1 text-[10px] rounded"
+              style={{
+                backgroundColor: tk(flat, 'digitv2.alert-info-bg', '#FFF3CD'),
+                color: tk(flat, 'warning-dark', '#9E5F00'),
+              }}
+              data-token="colors.warning-dark"
+            >
+              ⚠  Warning badge
+            </div>
+          </div>
+
+          {/* Disabled input + button */}
+          <div className="flex gap-1.5 items-center">
+            <input
+              type="text"
+              disabled
+              placeholder="Disabled input"
+              className="flex-1 text-[10px] px-2 py-1 rounded border"
+              style={{
+                borderColor: tk(flat, 'input-border', '#464646'),
+                color: tk(flat, 'digitv2.text-color-disabled', '#B1B4B6'),
+              }}
+              data-token="colors.input-border colors.digitv2.text-color-disabled"
+            />
+            <button
+              type="button"
+              disabled
+              className="text-[10px] font-medium px-2 py-1 rounded"
+              style={{
+                backgroundColor: tk(flat, 'grey.disabled', '#C5C5C5'),
+                color: tk(flat, 'digitv2.text-color-disabled', '#FFF'),
+              }}
+              data-token="colors.grey.disabled colors.digitv2.text-color-disabled"
+            >
+              Disabled
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/admin/themeEditor/hoverContext.ts
+++ b/src/admin/themeEditor/hoverContext.ts
@@ -1,0 +1,59 @@
+import { createContext, useContext, useRef, useCallback, type RefObject } from 'react';
+
+/**
+ * DOM-level hover highlight for the theme preview.
+ *
+ * Why DOM-level and not React state: hovering 38 color fields in quick
+ * succession would trigger 38 re-renders of ThemePreview (and its `useWatch`
+ * child). Instead, we mutate a single attribute on the preview root and let
+ * a short imperative pass toggle a class on matching `[data-token]` elements.
+ * Zero React re-renders, no context value churn.
+ */
+export interface HoverContextValue {
+  previewRootRef: RefObject<HTMLDivElement | null>;
+  setHoveredToken: (token: string | null) => void;
+}
+
+const HIGHLIGHT_CLASS = 'theme-token-hover';
+
+const HoverContext = createContext<HoverContextValue | null>(null);
+
+export function useHoverContext(): HoverContextValue | null {
+  return useContext(HoverContext);
+}
+
+export { HoverContext };
+
+/** Creates the setter paired with a ref to the preview root. Call once at
+ *  the editor level and pass the pair down via context. */
+export function useCreateHoverContext(): HoverContextValue {
+  const previewRootRef = useRef<HTMLDivElement | null>(null);
+  const lastSelectorRef = useRef<string | null>(null);
+
+  const setHoveredToken = useCallback((token: string | null) => {
+    const root = previewRootRef.current;
+    if (!root) return;
+    // Clear previous highlights.
+    if (lastSelectorRef.current) {
+      root.querySelectorAll(`.${HIGHLIGHT_CLASS}`).forEach((el) => {
+        el.classList.remove(HIGHLIGHT_CLASS);
+      });
+      lastSelectorRef.current = null;
+    }
+    if (!token) return;
+    // CSS attribute selectors can't have escaped commas / colons without quoting,
+    // so we filter by exact match against the full token path stored on data-token.
+    // Multiple tokens on one element are space-separated (e.g. "colors.border colors.input-border").
+    const matches = Array.from(root.querySelectorAll<HTMLElement>('[data-token]'))
+      .filter((el) => {
+        const list = el.dataset.token?.split(/\s+/) ?? [];
+        return list.includes(token);
+      });
+    matches.forEach((el) => el.classList.add(HIGHLIGHT_CLASS));
+    lastSelectorRef.current = token;
+  }, []);
+
+  return { previewRootRef, setHoveredToken };
+}
+
+export const HIGHLIGHT_CLASS_NAME = HIGHLIGHT_CLASS;

--- a/src/admin/themeEditor/index.ts
+++ b/src/admin/themeEditor/index.ts
@@ -1,0 +1,17 @@
+import type { ComponentType } from 'react';
+import { ThemeConfigEditor } from './ThemeConfigEditor';
+
+/**
+ * Registry of custom editors keyed by the `customEditor` field on
+ * SchemaDescriptor. MdmsResourceEdit consults this map; when a key is set
+ * and resolves, the generic form is bypassed in favor of the custom one.
+ *
+ * Keep this map tiny — custom editors are the exception, not the rule.
+ * Every schema that can be served by the descriptor + widget system should
+ * stay on that path.
+ */
+export const customEditors: Record<string, ComponentType> = {
+  'theme-config': ThemeConfigEditor,
+};
+
+export { ThemeConfigEditor };


### PR DESCRIPTION
## Summary
- Flagship custom editor for `common-masters.ThemeConfig` records. Replaces the 38-hex-text-input form with 6 Radix Tabs of grouped color pickers plus a miniature DIGIT-UI preview that lights up matching elements when you hover any color field.
- Adds a `customEditor?: string` escape hatch on `SchemaDescriptor` so schemas can opt into a dedicated component while descriptors stay serializable. Purely additive — existing descriptors unchanged.
- New widget: `BooleanInput` (plus `help` text on `DigitFormInput`) so descriptors with native bool fields round-trip cleanly.

## How it works
- `ThemePreview` subscribes to `colors` via one `useWatch` — isolates re-renders to the preview, keeps individual ColorInputs at field-level subscription.
- Hover-to-highlight is DOM mutation only (querySelectorAll + classList.add). Zero React re-renders across 38 rapidly-hovered fields.
- Every preview element tags `data-token="colors.foo.bar"` (space-separated when multiple tokens apply). Outlines pulse via a scoped `.theme-token-hover` CSS class.
- Editor wraps `DigitEdit` so save/cancel/dirty/error inherited from existing machinery.

## Out of scope for v1
- Live `/digit-ui/employee` iframe with palette injected via postMessage
- Country-preset dropdown (KE-green / IN-orange / etc)
- JSON import/export
- Contrast-ratio AA/AAA badge

## Test plan
- [x] Deployed on naipepea at `index-BrMeKdi9.js`; `/configurator/manage/theme-config/kenya-green` renders the grouped tabs + live preview
- [ ] Reload, hover each color field, verify the matching preview element outlines
- [ ] Edit `colors.primary.main` → preview button updates on every keystroke
- [ ] Save → re-open → values persisted in MDMS

🤖 Generated with [Claude Code](https://claude.com/claude-code)