### PR TITLE
dept/desig: hot-fix forms — array department, active toggles, description

### DIFF
--- a/src/resources/departments/DepartmentCreate.tsx
+++ b/src/resources/departments/DepartmentCreate.tsx
@@ -1,10 +1,13 @@
 import { DigitCreate, DigitFormCodeInput, DigitFormInput, v } from '@/admin';
+import { BooleanInput } from '@/admin/widgets';
 
 export function DepartmentCreate() {
   return (
     <DigitCreate title="Create Department" record={{ active: true }}>
       <DigitFormInput source="name" label="Name" validate={v.name} />
       <DigitFormCodeInput source="code" label="Code" deriveFrom="name" validate={v.codeRequired} />
+      <DigitFormInput source="description" label="Description" />
+      <BooleanInput source="active" label="Active" />
     </DigitCreate>
   );
 }

--- a/src/resources/departments/DepartmentEdit.tsx
+++ b/src/resources/departments/DepartmentEdit.tsx
@@ -1,4 +1,5 @@
 import { DigitEdit, DigitFormInput, v } from '@/admin';
+import { BooleanInput } from '@/admin/widgets';
 
 export function DepartmentEdit() {
   return (
@@ -6,6 +7,7 @@ export function DepartmentEdit() {
       <DigitFormInput source="code" label="Code" disabled />
       <DigitFormInput source="name" label="Name" validate={v.name} />
       <DigitFormInput source="description" label="Description" />
+      <BooleanInput source="active" label="Active" />
     </DigitEdit>
   );
 }

--- a/src/resources/designations/DepartmentChipInput.tsx
+++ b/src/resources/designations/DepartmentChipInput.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
+import { useGetList, useInput } from 'ra-core';
+import { ChevronDown, X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface DepartmentChipInputProps {
+  source?: string;
+  label?: string;
+  help?: string;
+}
+
+interface DeptRecord {
+  id: string | number;
+  code?: string;
+  name?: string;
+}
+
+/** Multi-select combobox backed by the `departments` resource. Writes a
+ *  `string[]` of department codes — the shape `common-masters.Designation`'s
+ *  MDMS schema declares for `department` (`type: array, items: string`).
+ *  Legacy records that stored a single string are coerced to a one-element
+ *  array on load so edit round-trips don't lose data. */
+export function DepartmentChipInput({
+  source = 'department',
+  label = 'Departments',
+  help,
+}: DepartmentChipInputProps) {
+  const { id, field, fieldState, isRequired } = useInput({ source });
+
+  const { data, isLoading } = useGetList<DeptRecord>('departments', {
+    pagination: { page: 1, perPage: 500 },
+    sort: { field: 'name', order: 'ASC' },
+  });
+
+  const codes: string[] = useMemo(() => {
+    const v = field.value;
+    if (Array.isArray(v)) return v.filter((x) => typeof x === 'string') as string[];
+    if (typeof v === 'string' && v) return [v];
+    return [];
+  }, [field.value]);
+
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const listboxId = `${id}-listbox`;
+
+  const byCode = useMemo(() => {
+    const m = new Map<string, DeptRecord>();
+    for (const d of data ?? []) {
+      const code = d.code ?? String(d.id);
+      if (code) m.set(code, d);
+    }
+    return m;
+  }, [data]);
+
+  const selectedSet = useMemo(() => new Set(codes), [codes]);
+
+  const options = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return (data ?? [])
+      .filter((d) => {
+        const code = d.code ?? String(d.id);
+        return !selectedSet.has(code);
+      })
+      .filter((d) => {
+        if (!q) return true;
+        const code = (d.code ?? '').toLowerCase();
+        const name = (d.name ?? '').toLowerCase();
+        return code.includes(q) || name.includes(q);
+      });
+  }, [data, selectedSet, query]);
+
+  useEffect(() => setActiveIdx(0), [query, options.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  const addCode = (code: string) => {
+    if (!code || selectedSet.has(code)) return;
+    field.onChange([...codes, code]);
+    setQuery('');
+  };
+
+  const removeCode = (code: string) => {
+    field.onChange(codes.filter((c) => c !== code));
+  };
+
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setOpen(true);
+      setActiveIdx((i) => Math.min(options.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter' && open && options.length > 0) {
+      e.preventDefault();
+      const pick = options[activeIdx] ?? options[0];
+      if (pick) addCode(pick.code ?? String(pick.id));
+    } else if (e.key === 'Escape') {
+      setOpen(false);
+    } else if (e.key === 'Backspace' && !query && codes.length > 0) {
+      removeCode(codes[codes.length - 1]);
+    }
+  };
+
+  const hasError = fieldState.invalid && fieldState.isTouched;
+  const errorMessage = fieldState.error?.message;
+
+  return (
+    <div ref={containerRef} className="relative">
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {isRequired && <span className="text-destructive ml-0.5" aria-label="required">*</span>}
+        </Label>
+      )}
+
+      <div className="flex flex-wrap gap-1.5 mb-1.5" aria-live="polite">
+        {codes.map((code) => {
+          const d = byCode.get(code);
+          return (
+            <span
+              key={code}
+              className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-primary/10 text-primary text-xs font-medium"
+            >
+              <span className="font-semibold">{code}</span>
+              {d?.name ? <span className="opacity-80">{d.name}</span> : null}
+              <button
+                type="button"
+                onClick={() => removeCode(code)}
+                aria-label={`remove ${code}`}
+                className="hover:text-destructive"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </span>
+          );
+        })}
+      </div>
+
+      <div className="relative">
+        <Input
+          id={id}
+          type="text"
+          role="combobox"
+          autoComplete="off"
+          aria-expanded={open}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          aria-invalid={hasError || undefined}
+          placeholder={isLoading ? 'Loading departments…' : 'Search departments…'}
+          disabled={isLoading}
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setOpen(true); }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={handleKey}
+          onBlur={field.onBlur}
+          className={'pr-8 ' + (hasError ? 'border-destructive focus-visible:ring-destructive' : '')}
+        />
+        <ChevronDown
+          aria-hidden
+          className={
+            'pointer-events-none absolute right-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground transition-transform ' +
+            (open ? 'rotate-180' : '')
+          }
+        />
+      </div>
+
+      {open && !isLoading && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="absolute z-20 mt-1 max-h-56 w-full overflow-auto rounded-md border border-input bg-popover text-popover-foreground shadow-md"
+        >
+          {options.length === 0 ? (
+            <li className="px-3 py-2 text-xs text-muted-foreground">
+              {(data ?? []).length === 0 ? 'No departments available' : 'No matches'}
+            </li>
+          ) : (
+            options.map((opt, idx) => {
+              const code = opt.code ?? String(opt.id);
+              return (
+                <li
+                  key={code}
+                  role="option"
+                  aria-selected={idx === activeIdx}
+                  onMouseDown={(e) => { e.preventDefault(); addCode(code); }}
+                  onMouseEnter={() => setActiveIdx(idx)}
+                  className={
+                    'cursor-pointer px-3 py-1.5 text-sm ' +
+                    (idx === activeIdx ? 'bg-accent text-accent-foreground' : '')
+                  }
+                >
+                  <span className="font-medium">{code}</span>
+                  {opt.name ? <span className="ml-2 text-muted-foreground">{opt.name}</span> : null}
+                </li>
+              );
+            })
+          )}
+        </ul>
+      )}
+
+      {hasError && errorMessage && (
+        <p className="mt-1 text-xs text-destructive" role="alert">{errorMessage}</p>
+      )}
+      {!hasError && help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/src/resources/designations/DesignationCreate.tsx
+++ b/src/resources/designations/DesignationCreate.tsx
@@ -1,17 +1,19 @@
-import { DigitCreate, DigitFormCodeInput, DigitFormInput, DigitFormSelect, v } from '@/admin';
+import { DigitCreate, DigitFormCodeInput, DigitFormInput, v } from '@/admin';
+import { BooleanInput } from '@/admin/widgets';
+import { DepartmentChipInput } from './DepartmentChipInput';
 
 export function DesignationCreate() {
   return (
-    <DigitCreate title="Create Designation" record={{ active: true }}>
+    <DigitCreate title="Create Designation" record={{ active: true, department: [] }}>
       <DigitFormInput source="name" label="Name" validate={v.name} />
       <DigitFormCodeInput source="code" label="Code" deriveFrom="name" validate={v.codeRequired} />
       <DigitFormInput source="description" label="Description" validate={v.required} />
-      <DigitFormSelect
+      <DepartmentChipInput
         source="department"
-        label="Department"
-        reference="departments"
-        placeholder="Select department..."
+        label="Departments"
+        help="Pick one or more. Stored as an array per the MDMS schema."
       />
+      <BooleanInput source="active" label="Active" />
     </DigitCreate>
   );
 }

--- a/src/resources/designations/DesignationEdit.tsx
+++ b/src/resources/designations/DesignationEdit.tsx
@@ -1,17 +1,19 @@
-import { DigitEdit, DigitFormInput, DigitFormSelect, v } from '@/admin';
+import { DigitEdit, DigitFormInput, v } from '@/admin';
+import { BooleanInput } from '@/admin/widgets';
+import { DepartmentChipInput } from './DepartmentChipInput';
 
 export function DesignationEdit() {
   return (
     <DigitEdit title="Edit Designation">
       <DigitFormInput source="code" label="Code" disabled />
       <DigitFormInput source="name" label="Name" validate={v.name} />
-      <DigitFormInput source="description" label="Description" />
-      <DigitFormSelect
+      <DigitFormInput source="description" label="Description" validate={v.required} />
+      <DepartmentChipInput
         source="department"
-        label="Department"
-        reference="departments"
-        placeholder="Select department..."
+        label="Departments"
+        help="This designation can belong to multiple departments."
       />
+      <BooleanInput source="active" label="Active" />
     </DigitEdit>
   );
 }

--- a/src/resources/designations/DesignationShow.tsx
+++ b/src/resources/designations/DesignationShow.tsx
@@ -1,6 +1,6 @@
 import { DigitShow } from '@/admin';
-import { FieldSection, FieldRow, ReverseReferenceList } from '@/admin/fields';
-import { StatusChip } from '@/admin/fields';
+import { FieldSection, FieldRow, ReverseReferenceList, StatusChip } from '@/admin/fields';
+import { EntityLink } from '@/components/ui/EntityLink';
 import { useShowController } from 'ra-core';
 
 export function DesignationShow() {
@@ -8,28 +8,48 @@ export function DesignationShow() {
 
   return (
     <DigitShow title={record ? `Designation: ${record.name ?? record.id}` : 'Designation'} hasEdit>
-      {(rec: Record<string, unknown>) => (
-        <div className="space-y-6">
-          <FieldSection title="Details">
-            <FieldRow label="Code">{String(rec.code ?? '')}</FieldRow>
-            <FieldRow label="Name">{String(rec.name ?? '')}</FieldRow>
-            <FieldRow label="Status">
-              <StatusChip value={rec.active} labels={{ true: 'Active', false: 'Inactive' }} />
-            </FieldRow>
-            <FieldRow label="Description">{String(rec.description ?? '--')}</FieldRow>
-          </FieldSection>
+      {(rec: Record<string, unknown>) => {
+        const raw = rec.department;
+        const deptCodes: string[] = Array.isArray(raw)
+          ? (raw.filter((x) => typeof x === 'string') as string[])
+          : typeof raw === 'string' && raw
+          ? [raw]
+          : [];
 
-          <FieldSection title="Related">
-            <ReverseReferenceList
-              resource="employees"
-              target="assignments.designation"
-              id={String(rec.code ?? rec.id)}
-              label="Employees"
-              displayField="code"
-            />
-          </FieldSection>
-        </div>
-      )}
+        return (
+          <div className="space-y-6">
+            <FieldSection title="Details">
+              <FieldRow label="Code">{String(rec.code ?? '')}</FieldRow>
+              <FieldRow label="Name">{String(rec.name ?? '')}</FieldRow>
+              <FieldRow label="Status">
+                <StatusChip value={rec.active} labels={{ true: 'Active', false: 'Inactive' }} />
+              </FieldRow>
+              <FieldRow label="Description">{String(rec.description ?? '--')}</FieldRow>
+              <FieldRow label="Departments">
+                {deptCodes.length === 0 ? (
+                  <span className="text-muted-foreground">--</span>
+                ) : (
+                  <div className="flex flex-wrap gap-1.5">
+                    {deptCodes.map((code) => (
+                      <EntityLink key={code} resource="departments" id={code} />
+                    ))}
+                  </div>
+                )}
+              </FieldRow>
+            </FieldSection>
+
+            <FieldSection title="Related">
+              <ReverseReferenceList
+                resource="employees"
+                target="assignments.designation"
+                id={String(rec.code ?? rec.id)}
+                label="Employees"
+                displayField="code"
+              />
+            </FieldSection>
+          </div>
+        );
+      }}
     </DigitShow>
   );
 }


### PR DESCRIPTION
## Summary

Brings `/manage/departments/*` and `/manage/designations/*` in line with the MDMS schema. Four hot bugs fixed in one patch; machinery validated against naipepea before shipping.

| # | Bug | Fix |
|---|---|---|
| 1 | `DesignationEdit` / `Create` used a single `DigitFormSelect` for `department`, but the MDMS schema declares `department: array<string>`. Multi-dept designations silently truncated on save. | New `DepartmentChipInput` (combobox + chips, same pattern as `RolesEditor`), writes `string[]`. Legacy single-string values coerced to one-element arrays on load so edit round-trips preserve data. |
| 2 | No way to flip `active` from the /manage forms. | `BooleanInput` wired into both Dept + Desig Create / Edit. |
| 3 | `description` present on `DepartmentEdit` but missing from `DepartmentCreate` — inconsistent. | Added to Create. |
| 4 | `DesignationShow` didn't render the designation's own departments. | Chips of `EntityLink`s to each department. |

## API shape validation

Before shipping, probed `ChakshuGautam/digit-configurator`'s target DIGIT stack on naipepea:

**Schema** — `POST /mdms-v2/schema/v1/_search` for `common-masters.Designation`:
```
required: [code, name, description, active]
  department: type=array  items=string
```
Confirmed live records already use array form (3 of 37 have `department` populated, all arrays, 0 strings) — no FE-side back-compat shim needed beyond the load-coercion.

**Create round-trip** — `POST /mdms-v2/v2/_create/common-masters.Designation` with:
```json
{\"data\": {\"code\":\"PROBE_DESIG_ARR\", \"name\":\"Probe\", \"description\":\"...\",
         \"active\": true, \"department\": [\"DEPT_07\",\"DEPT_08\"]}}
```
Returned 200. Search read back `department: [\"DEPT_07\",\"DEPT_08\"]` identical.

**Soft-delete** — `POST /mdms-v2/v2/_update/common-masters.Designation` with the existing record and `isActive: false` at the wrapper level. Search returns `isActive=False, data.active=True` (wrapper flipped, domain field preserved). Clean.

Probe record cleaned up; no test junk on tenant `ke`.

## Testing plan

- [ ] Navigate to `/manage/designations/create`. Type a name → code auto-derives. Pick 2 departments in the chip input. Save. Record persists with `department: [code1, code2]` (verify via MDMS search).
- [ ] Open an existing designation in Edit. Add a third department. Save. Re-open. All three chips render. Remove one. Save. Only two persist.
- [ ] `DesignationShow` of the same record — all departments render as clickable `EntityLink` chips.
- [ ] Flip `Active` off from `DesignationEdit`. Save. Record disappears from the default list (filter = active).
- [ ] On `DepartmentCreate`, fill name → code derives → add description → uncheck Active → save. Record persists with `data.active = false`.
- [ ] Existing single-string designation (rare but possible in old data) loads into Edit as one chip — no data loss.

## Clash analysis

No overlap with the bulk-import work (`fd1075d`) or mobile validator work — this PR only touches `src/resources/departments/*` and `src/resources/designations/*` plus a new `DepartmentChipInput.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Departments now include an "active" toggle and description field
  * Designations can be assigned to multiple departments instead of one
  * Designations include an "active" toggle
  * Department links now display in designation details view

* **Improvements**
  * Added required validation for designation descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->