### PR TITLE
complaints: persist edit fields + citizen on create + drop pg/statea fallbacks

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -417,11 +417,19 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
       }
       if (config.type === 'pgr') {
         const data = params.data as Record<string, unknown>;
+        // Stamp address.tenantId from the session tenant. Live PGR records
+        // always carry address.tenantId (never address.city, which is nullable
+        // and unused downstream). Operators don't fill this manually.
+        const formAddress = (data.address as Record<string, unknown> | undefined) ?? {};
+        const address: Record<string, unknown> = { ...formAddress, tenantId };
+        if (!address.locality && typeof data['address.locality.code'] === 'string') {
+          address.locality = { code: data['address.locality.code'] };
+        }
         const wrapper = await client.pgrCreate(
           tenantId,
           String(data.serviceCode),
           String(data.description || ''),
-          (data.address || { locality: { code: '' } }) as Record<string, unknown>,
+          address,
           data.citizen as Record<string, unknown> | undefined,
         );
         const service = ((wrapper as Record<string, unknown>).service || wrapper) as Record<string, unknown>;
@@ -487,10 +495,27 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
       if (config.type === 'pgr') {
         const data = params.data as Record<string, unknown>;
         const action = String(data.action || data._action || 'ASSIGN');
-        // Fetch current service state
+        // Fetch current service state — PGR update needs the full object
+        // (auditDetails round-trip, internal UUID, etc.).
         const wrappers = await client.pgrSearch(tenantId, { serviceRequestId: String(params.id) });
         if (!wrappers.length) throw new Error(`Complaint not found: ${params.id}`);
         const service = ((wrappers[0] as Record<string, unknown>).service || wrappers[0]) as Record<string, unknown>;
+
+        // Merge form edits onto the fetched service so description / serviceCode
+        // / source / address changes actually persist. Previously these were
+        // silently dropped — the update path sent the fetched service verbatim
+        // and only the workflow action, comment, assignees, and rating survived.
+        const editableTop = ['serviceCode', 'description', 'source', 'additionalDetail'];
+        for (const key of editableTop) {
+          if (key in data) service[key] = data[key];
+        }
+        if (data.address && typeof data.address === 'object') {
+          service.address = {
+            ...(service.address as Record<string, unknown> | undefined ?? {}),
+            ...(data.address as Record<string, unknown>),
+          };
+        }
+
         // Normalize assignees: accept a single string (from form select) or an array
         let assignees: string[] | undefined;
         if (data.assignee) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,9 +154,13 @@ function restoreApiClientFromStorage(): { isAuthenticated: boolean; user: AppSta
       });
       apiClient.setTenantId(parsed.tenant);
 
-      // Also configure the shared digitClient from the bridge
+      // Also configure the shared digitClient from the bridge. If the stored
+      // session lacks a tenant, bail — there's no sensible default (a stale
+      // `'statea'` or `'pg'` fallback silently attached operators to the wrong
+      // tenant and hid the real "re-login" needed).
       const restoredEnv = parsed.environment || getApiBaseUrl();
-      const restoredTenant = parsed.tenant || 'statea';
+      const restoredTenant = parsed.tenant;
+      if (!restoredTenant) return null;
       configureDigitClient(restoredEnv, parsed.authToken, {
         id: parsed.user.id ?? 0,
         uuid: parsed.user.uuid ?? '',

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -202,7 +202,7 @@ export default function LoginPage() {
                 <button
                   type="button"
                   className="text-muted-foreground hover:text-primary"
-                  title="Root tenant for authentication (e.g., 'pg' for Punjab)"
+                  title="Root (state-level) tenant code — e.g. 'ke' for Kenya, 'pg' for Punjab."
                 >
                   <HelpCircle className="w-3.5 h-3.5" />
                 </button>
@@ -213,7 +213,7 @@ export default function LoginPage() {
                   type="text"
                   value={formData.tenantCode}
                   onChange={(e) => setFormData({ ...formData, tenantCode: e.target.value })}
-                  placeholder="pg"
+                  placeholder="ke"
                   className="border-input-border focus:border-primary focus:ring-primary"
                   required
                 />

--- a/src/providers/i18nProvider.ts
+++ b/src/providers/i18nProvider.ts
@@ -475,7 +475,12 @@ async function fetchAppTranslations(locale: string): Promise<Record<string, stri
   if (cached) return cached;
 
   try {
-    const tenantId = digitClient.stateTenantId || 'pg';
+    const tenantId = digitClient.stateTenantId;
+    // No session tenant yet → no translations to fetch. Returning empty lets
+    // the UI fall through to the bundled English strings instead of pointing
+    // the localization call at a hardcoded `'pg'` that doesn't exist on every
+    // deployment.
+    if (!tenantId) return {};
     const messages = await digitClient.localizationSearch(tenantId, locale, 'configurator-ui');
     const flat: Record<string, string> = {};
     for (const msg of messages) {

--- a/src/resources/complaints/ComplaintCreate.tsx
+++ b/src/resources/complaints/ComplaintCreate.tsx
@@ -1,24 +1,81 @@
 import { DigitCreate, DigitFormInput, DigitFormSelect, v } from '@/admin';
+import { FieldSection } from '@/admin/fields';
+import { useApp } from '../../App';
 
 export function ComplaintCreate() {
+  const { state } = useApp();
+  const tenantId = state.tenant;
+
+  const transform = (data: Record<string, unknown>): Record<string, unknown> => {
+    // Citizen must be stamped at the state tenant (user-service upserts
+    // CITIZEN-type users by mobileNumber at the state level).
+    const citizenInput = (data.citizen as Record<string, unknown> | undefined) ?? {};
+    const mobile = typeof citizenInput.mobileNumber === 'string' ? citizenInput.mobileNumber.trim() : '';
+    const stateTenant = tenantId.split('.')[0];
+    const citizen = mobile
+      ? {
+          name: typeof citizenInput.name === 'string' && citizenInput.name ? citizenInput.name : mobile,
+          mobileNumber: mobile,
+          emailId: typeof citizenInput.emailId === 'string' ? citizenInput.emailId : undefined,
+          type: 'CITIZEN',
+          tenantId: stateTenant,
+          roles: [{ code: 'CITIZEN', name: 'Citizen', tenantId: stateTenant }],
+        }
+      : undefined;
+    return { ...data, citizen };
+  };
+
   return (
-    <DigitCreate title="File Complaint" record={{ 'address.city': 'pg' }}>
-      <DigitFormSelect
-        source="serviceCode"
-        label="Complaint Type"
-        reference="complaint-types"
-        optionValue="serviceCode"
-        placeholder="Select complaint type..."
-        validate={v.required}
-      />
-      <DigitFormInput source="description" label="Description" validate={[v.required, v.minLength(10)]} />
-      <DigitFormSelect
-        source="address.locality.code"
-        label="Locality"
-        reference="boundaries"
-        placeholder="Select locality..."
-      />
-      <DigitFormInput source="address.city" label="City" />
+    <DigitCreate title="File Complaint" record={{}} transform={transform}>
+      <FieldSection title="Complaint">
+        <div className="space-y-4">
+          <DigitFormSelect
+            source="serviceCode"
+            label="Complaint Type"
+            reference="complaint-types"
+            optionValue="serviceCode"
+            placeholder="Select complaint type..."
+            validate={v.required}
+          />
+          <DigitFormInput
+            source="description"
+            label="Description"
+            validate={[v.required, v.minLength(10)]}
+            help="What happened? Minimum 10 characters."
+          />
+          <DigitFormSelect
+            source="address.locality.code"
+            label="Locality"
+            reference="boundaries"
+            placeholder="Select locality..."
+            validate={v.required}
+          />
+          <DigitFormInput source="address.landmark" label="Landmark" />
+          <DigitFormInput source="address.pincode" label="Pincode" />
+        </div>
+      </FieldSection>
+
+      <FieldSection title="Citizen">
+        <div className="space-y-4">
+          <DigitFormInput
+            source="citizen.mobileNumber"
+            label="Mobile number"
+            validate={v.required}
+            help="Used to identify the citizen. User-service upserts a CITIZEN account by mobile."
+          />
+          <DigitFormInput
+            source="citizen.name"
+            label="Name"
+            help="Optional. Defaults to the mobile number if left blank."
+          />
+          <DigitFormInput
+            source="citizen.emailId"
+            label="Email"
+            type="email"
+            validate={v.emailOptional}
+          />
+        </div>
+      </FieldSection>
     </DigitCreate>
   );
 }

--- a/src/resources/complaints/ComplaintEdit.tsx
+++ b/src/resources/complaints/ComplaintEdit.tsx
@@ -63,7 +63,9 @@ export function ComplaintEdit() {
             reference="boundaries"
             placeholder="Select locality..."
           />
-          <DigitFormInput source="address.city" label="City" />
+          <DigitFormInput source="address.landmark" label="Landmark" />
+          <DigitFormInput source="address.pincode" label="Pincode" />
+          <DigitFormInput source="address.street" label="Street" />
         </div>
       </FieldSection>
     </DigitEdit>


### PR DESCRIPTION
## Summary

Three related fixes; two functional bugs on the complaint surface plus a hardcoding sweep so future Kenya-specific deployments don't trip on Punjab defaults.

### Edit silently dropped field changes

`dataProvider.update` for the `pgr` config fetched the existing service from `pgrSearch` and passed it verbatim to `pgrUpdate`, overwriting anything the operator typed. Only workflow action / comment / assignees / rating survived.

Now merges form data onto the fetched service before `pgrUpdate`:
- `serviceCode`, `description`, `source`, `additionalDetail` at the top level.
- `address.*` deep-merged so `locality.code`, `landmark`, `pincode`, `street`, `buildingName` persist next to server-stamped `tenantId` / `geoLocation`.

### Create had `address.city: 'pg'` default

Punjab leftover. `address.city` is `null` on every live complaint (tenant-scoping comes from `address.tenantId`). Removed. Data-provider now stamps `address.tenantId` from the session tenant. Form exposes `landmark` / `pincode` — fields real records use.

### Create had no citizen fields

Without them, `DigitApiClient.pgrCreate` fell back to the logged-in operator's userInfo as the citizen — every manually-filed complaint was attributed to the CSR/GRO. Added mobile / name / email; a `transform` assembles the citizen object at the **state** tenant (user-service upserts CITIZEN users by mobileNumber at state level, not city).

### Hardcoding cleanup

| File | Was | Now |
|---|---|---|
| `src/App.tsx` | `parsed.tenant \|\| 'statea'` in auth-restore | Missing tenant → return null, force re-login |
| `src/providers/i18nProvider.ts` | `digitClient.stateTenantId \|\| 'pg'` | Missing → empty translations, fall through to bundled strings |
| `src/pages/LoginPage.tsx` | placeholder `pg`, tooltip Punjab-specific | placeholder `ke`, tooltip generalized |

## API shape validation (live against naipepea)

**Create** — `POST /pgr-services/v2/request/_create` with the fixed payload:
```json
{\"service\": {
  \"tenantId\": \"ke.nairobi\",
  \"serviceCode\": \"ContractDispute\",
  \"description\": \"…\",
  \"source\": \"web\",
  \"citizen\": {\"name\": \"0722999001\", \"mobileNumber\": \"0722999001\",
               \"type\": \"CITIZEN\", \"tenantId\": \"ke\",
               \"roles\": [{\"code\": \"CITIZEN\", \"name\": \"Citizen\", \"tenantId\": \"ke\"}]},
  \"address\": {\"tenantId\": \"ke.nairobi\", \"locality\": {\"code\": \"NAIROBI_CITY_VIWANDANI\"},
               \"landmark\": \"…\", \"pincode\": \"00100\",
               \"geoLocation\": {\"latitude\": 0, \"longitude\": 0}}
}, \"workflow\": {\"action\": \"APPLY\"}}
```
Returned `PG-PGR-2026-04-23-004412` with every field round-tripped, `applicationStatus=PENDINGFORASSIGNMENT`.

**Update (merge path)** — `POST /pgr-services/v2/request/_update` with the fetched service plus a modified `description` and `workflow.action=REJECT`:
```
OK status=REJECTED  desc=[merge-update probe] description changed
```
Description persisted **and** the workflow action applied in the same round-trip — exactly what the FE path does after this fix.

Probe complaint terminated via `REJECT`; no active probe data on the tenant.

Also checked: `source: 'counter'` is rejected server-side with `INVALID_SOURCE`. The FE's current `SOURCE_CHOICES` (`web / mobile / whatsapp / ivr / counter`) contains a code the server's allow-list doesn't recognize on `ke.nairobi` today. Not blocking this PR (operators default to `web`), but flagged for follow-up in PR 3's workflow cleanup.

## Files

- `packages/data-provider/src/providers/dataProvider.ts` — merge-on-update + tenant-stamp-on-create.
- `src/resources/complaints/ComplaintCreate.tsx` — rewritten with citizen section, landmark, pincode.
- `src/resources/complaints/ComplaintEdit.tsx` — replaced `address.city` field with `landmark / pincode / street`.
- `src/App.tsx` — drop `'statea'` fallback.
- `src/providers/i18nProvider.ts` — drop `'pg'` fallback.
- `src/pages/LoginPage.tsx` — copy + placeholder.

## Testing plan

- [ ] File a complaint from `/manage/complaints/create` with a Kenya citizen mobile + locality; it persists with `address.tenantId=<session>`, no stray `city: 'pg'`, and a CITIZEN user is upserted at state tenant `ke`.
- [ ] Open an existing complaint in Edit, change the description, pick a workflow action, save. Description **and** the workflow transition both persist (was silently dropping the description before).
- [ ] Clear localStorage auth → restart → login screen's tenant-code placeholder shows `ke`, not `pg`.

## Clash analysis

- Builds on #3, #5, #6. No overlap with the HRMS mobile-validator work (`useMobileValidator`) or the dept/desig surfaces.
- `WorkflowActionSelect` and the server-side source allow-list are deliberately **not** touched here — PR 3 handles supervisor-state / source-list alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)