### PR TITLE
complaints: cascading locality, full 11-state workflow, mobile-only citizen display

### DIFF
--- a/packages/data-provider/src/client/DigitApiClient.ts
+++ b/packages/data-provider/src/client/DigitApiClient.ts
@@ -431,6 +431,20 @@ export class DigitApiClient {
     return data.ServiceWrappers || [];
   }
 
+  async pgrCount(tenantId: string, options?: {
+    status?: string; fromDate?: number; toDate?: number;
+  }): Promise<number> {
+    const params = new URLSearchParams({ tenantId });
+    if (options?.status) params.append('applicationStatus', options.status);
+    if (options?.fromDate) params.append('fromDate', String(options.fromDate));
+    if (options?.toDate) params.append('toDate', String(options.toDate));
+    const data = await this.request<{ count?: number }>(
+      `${this.endpoint('PGR_COUNT')}?${params.toString()}`,
+      { RequestInfo: this.buildRequestInfo() },
+    );
+    return typeof data.count === 'number' ? data.count : 0;
+  }
+
   async pgrCreate(tenantId: string, serviceCode: string, description: string, address: Record<string, unknown>, citizen?: Record<string, unknown>): Promise<Record<string, unknown>> {
     const citizenInfo = citizen || (this.userInfo ? {
       mobileNumber: this.userInfo.mobileNumber || '0000000000', name: this.userInfo.name, type: 'CITIZEN',

--- a/packages/data-provider/src/client/endpoints.ts
+++ b/packages/data-provider/src/client/endpoints.ts
@@ -28,6 +28,7 @@ export const ENDPOINTS = {
   PGR_CREATE: '/pgr-services/v2/request/_create',
   PGR_SEARCH: '/pgr-services/v2/request/_search',
   PGR_UPDATE: '/pgr-services/v2/request/_update',
+  PGR_COUNT: '/pgr-services/v2/request/_count',
   WORKFLOW_BUSINESS_SERVICE_SEARCH: '/egov-workflow-v2/egov-wf/businessservice/_search',
   WORKFLOW_BUSINESS_SERVICE_CREATE: '/egov-workflow-v2/egov-wf/businessservice/_create',
   WORKFLOW_PROCESS_SEARCH: '/egov-workflow-v2/egov-wf/process/_search',

--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -307,6 +307,64 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
     async getList(resource, params): Promise<GetListResult> {
       const { page = 1, perPage = 25 } = params.pagination ?? {};
       const { field = 'id', order = 'ASC' } = params.sort ?? {};
+
+      // PGR complaints: push pagination + server-supported filters to the
+      // API. The old behavior pulled the first 100 records and paginated
+      // client-side, which silently truncated larger tenants. `_count`
+      // returns the real total so react-admin's paginator stays honest.
+      const config = resolveConfig(resource);
+      if (config.type === 'pgr') {
+        const filter = (params.filter ?? {}) as Record<string, unknown>;
+        const status = filter.applicationStatus ?? filter.status;
+        const fromDate = typeof filter.fromDate === 'number' ? filter.fromDate : undefined;
+        const toDate = typeof filter.toDate === 'number' ? filter.toDate : undefined;
+        const department =
+          typeof filter['additionalDetail.department'] === 'string'
+            ? filter['additionalDetail.department']
+            : typeof filter.department === 'string'
+            ? filter.department
+            : undefined;
+        const q = typeof filter.q === 'string' ? filter.q.trim() : undefined;
+
+        const searchOpts = {
+          status: typeof status === 'string' ? status : undefined,
+          fromDate,
+          toDate,
+          sortBy: field,
+          sortOrder: order,
+          limit: perPage,
+          offset: (page - 1) * perPage,
+        };
+        const [wrappers, total] = await Promise.all([
+          client.pgrSearch(tenantId, searchOpts),
+          client.pgrCount(tenantId, { status: searchOpts.status, fromDate, toDate }),
+        ]);
+        let records = wrappers.map((w) => {
+          const service = (w.service || w) as Record<string, unknown>;
+          return normalizeRecord(service, config);
+        });
+        // Client-side filters for fields the server's criteria don't cover.
+        if (department) {
+          records = records.filter((r) => {
+            const d = (r as Record<string, unknown>).additionalDetail as
+              | Record<string, unknown>
+              | undefined;
+            return d?.department === department;
+          });
+        }
+        if (q) {
+          const needle = q.toLowerCase();
+          records = records.filter((r) => {
+            const rec = r as Record<string, unknown>;
+            return (
+              String(rec.serviceRequestId ?? '').toLowerCase().includes(needle) ||
+              String(rec.description ?? '').toLowerCase().includes(needle)
+            );
+          });
+        }
+        return { data: records, total };
+      }
+
       const all = await fetchAll(resource, params.filter);
       const filtered = clientFilter(all, params.filter);
       const sorted = clientSort(filtered, field, order);

--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -417,11 +417,19 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
       }
       if (config.type === 'pgr') {
         const data = params.data as Record<string, unknown>;
+        // Stamp address.tenantId from the session tenant. Live PGR records
+        // always carry address.tenantId (never address.city, which is nullable
+        // and unused downstream). Operators don't fill this manually.
+        const formAddress = (data.address as Record<string, unknown> | undefined) ?? {};
+        const address: Record<string, unknown> = { ...formAddress, tenantId };
+        if (!address.locality && typeof data['address.locality.code'] === 'string') {
+          address.locality = { code: data['address.locality.code'] };
+        }
         const wrapper = await client.pgrCreate(
           tenantId,
           String(data.serviceCode),
           String(data.description || ''),
-          (data.address || { locality: { code: '' } }) as Record<string, unknown>,
+          address,
           data.citizen as Record<string, unknown> | undefined,
         );
         const service = ((wrapper as Record<string, unknown>).service || wrapper) as Record<string, unknown>;
@@ -487,10 +495,27 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
       if (config.type === 'pgr') {
         const data = params.data as Record<string, unknown>;
         const action = String(data.action || data._action || 'ASSIGN');
-        // Fetch current service state
+        // Fetch current service state — PGR update needs the full object
+        // (auditDetails round-trip, internal UUID, etc.).
         const wrappers = await client.pgrSearch(tenantId, { serviceRequestId: String(params.id) });
         if (!wrappers.length) throw new Error(`Complaint not found: ${params.id}`);
         const service = ((wrappers[0] as Record<string, unknown>).service || wrappers[0]) as Record<string, unknown>;
+
+        // Merge form edits onto the fetched service so description / serviceCode
+        // / source / address changes actually persist. Previously these were
+        // silently dropped — the update path sent the fetched service verbatim
+        // and only the workflow action, comment, assignees, and rating survived.
+        const editableTop = ['serviceCode', 'description', 'source', 'additionalDetail'];
+        for (const key of editableTop) {
+          if (key in data) service[key] = data[key];
+        }
+        if (data.address && typeof data.address === 'object') {
+          service.address = {
+            ...(service.address as Record<string, unknown> | undefined ?? {}),
+            ...(data.address as Record<string, unknown>),
+          };
+        }
+
         // Normalize assignees: accept a single string (from form select) or an array
         let assignees: string[] | undefined;
         if (data.assignee) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -154,9 +154,13 @@ function restoreApiClientFromStorage(): { isAuthenticated: boolean; user: AppSta
       });
       apiClient.setTenantId(parsed.tenant);
 
-      // Also configure the shared digitClient from the bridge
+      // Also configure the shared digitClient from the bridge. If the stored
+      // session lacks a tenant, bail — there's no sensible default (a stale
+      // `'statea'` or `'pg'` fallback silently attached operators to the wrong
+      // tenant and hid the real "re-login" needed).
       const restoredEnv = parsed.environment || getApiBaseUrl();
-      const restoredTenant = parsed.tenant || 'statea';
+      const restoredTenant = parsed.tenant;
+      if (!restoredTenant) return null;
       configureDigitClient(restoredEnv, parsed.authToken, {
         id: parsed.user.id ?? 0,
         uuid: parsed.user.uuid ?? '',

--- a/src/admin/WorkflowActionSelect.tsx
+++ b/src/admin/WorkflowActionSelect.tsx
@@ -13,6 +13,7 @@ import { Badge } from '@/components/ui/badge';
 import { DigitFormSelect } from './DigitFormSelect';
 
 interface WorkflowState {
+  uuid?: string;
   state: string | null;
   applicationStatus: string | null;
   isStartState?: boolean;
@@ -35,7 +36,10 @@ export interface WorkflowActionSelectProps extends InputProps {
   className?: string;
 }
 
-/** Human-readable labels for PGR workflow actions */
+/** Human-readable labels for PGR workflow actions. Superset of the actions
+ *  observed in the live `egov-workflow-v2/businessservice` PGR config
+ *  (probed 2026-04-23): APPLY, ASSIGN, REASSIGN, RESOLVE, REJECT, REOPEN,
+ *  RATE, ESCALATE, COMMENT, SLA_ESCALATE. */
 const ACTION_LABELS: Record<string, string> = {
   APPLY: 'Submit',
   ASSIGN: 'Assign to Employee',
@@ -44,17 +48,23 @@ const ACTION_LABELS: Record<string, string> = {
   REJECT: 'Reject',
   REOPEN: 'Reopen',
   RATE: 'Rate & Close',
+  ESCALATE: 'Escalate',
+  COMMENT: 'Add Comment',
+  SLA_ESCALATE: 'SLA Escalation (auto)',
 };
 
-/** Human-readable labels for PGR states */
+/** Human-readable labels for PGR states — covers the full 11-state machine. */
 const STATE_LABELS: Record<string, string> = {
   PENDINGFORASSIGNMENT: 'Pending Assignment',
   PENDINGFORREASSIGNMENT: 'Pending Reassignment',
   PENDINGATLME: 'Pending at LME',
+  PENDINGATSUPERVISOR: 'Pending at Supervisor',
   RESOLVED: 'Resolved',
+  RESOLVEDBYSUPERVISOR: 'Resolved by Supervisor',
   REJECTED: 'Rejected',
   CLOSEDAFTERRESOLUTION: 'Closed (Resolved)',
   CLOSEDAFTERREJECTION: 'Closed (Rejected)',
+  CANCELLED: 'Cancelled',
 };
 
 /** Actions that require selecting an assignee */
@@ -108,13 +118,24 @@ export function WorkflowActionSelect({
       return { currentState: null, availableActions: [], isTerminal: false };
     }
 
-    const actions = (state.actions ?? []).map((a) => ({
-      value: a.action,
-      label: ACTION_LABELS[a.action] ?? a.action,
-      nextState: a.nextState,
-      nextStateLabel: STATE_LABELS[a.nextState] ?? a.nextState,
-      roles: a.roles,
-    }));
+    // `nextState` on an action references the target state's *uuid*, not the
+    // applicationStatus label. Build a uuid→status map from workflowDef so
+    // operators see "→ Pending at LME" instead of a raw UUID in the dropdown.
+    const byUuid = new Map<string, string>();
+    for (const s of states) {
+      if (s.uuid && s.applicationStatus) byUuid.set(s.uuid, s.applicationStatus);
+    }
+
+    const actions = (state.actions ?? []).map((a) => {
+      const nextStatus = byUuid.get(a.nextState) ?? a.nextState;
+      return {
+        value: a.action,
+        label: ACTION_LABELS[a.action] ?? a.action,
+        nextState: nextStatus,
+        nextStateLabel: STATE_LABELS[nextStatus] ?? nextStatus,
+        roles: a.roles,
+      };
+    });
 
     return {
       currentState: state,

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -202,7 +202,7 @@ export default function LoginPage() {
                 <button
                   type="button"
                   className="text-muted-foreground hover:text-primary"
-                  title="Root tenant for authentication (e.g., 'pg' for Punjab)"
+                  title="Root (state-level) tenant code — e.g. 'ke' for Kenya, 'pg' for Punjab."
                 >
                   <HelpCircle className="w-3.5 h-3.5" />
                 </button>
@@ -213,7 +213,7 @@ export default function LoginPage() {
                   type="text"
                   value={formData.tenantCode}
                   onChange={(e) => setFormData({ ...formData, tenantCode: e.target.value })}
-                  placeholder="pg"
+                  placeholder="ke"
                   className="border-input-border focus:border-primary focus:ring-primary"
                   required
                 />

--- a/src/providers/i18nProvider.ts
+++ b/src/providers/i18nProvider.ts
@@ -475,7 +475,12 @@ async function fetchAppTranslations(locale: string): Promise<Record<string, stri
   if (cached) return cached;
 
   try {
-    const tenantId = digitClient.stateTenantId || 'pg';
+    const tenantId = digitClient.stateTenantId;
+    // No session tenant yet → no translations to fetch. Returning empty lets
+    // the UI fall through to the bundled English strings instead of pointing
+    // the localization call at a hardcoded `'pg'` that doesn't exist on every
+    // deployment.
+    if (!tenantId) return {};
     const messages = await digitClient.localizationSearch(tenantId, locale, 'configurator-ui');
     const flat: Record<string, string> = {};
     for (const msg of messages) {

--- a/src/resources/complaints/ComplaintCreate.tsx
+++ b/src/resources/complaints/ComplaintCreate.tsx
@@ -1,24 +1,81 @@
 import { DigitCreate, DigitFormInput, DigitFormSelect, v } from '@/admin';
+import { FieldSection } from '@/admin/fields';
+import { useApp } from '../../App';
 
 export function ComplaintCreate() {
+  const { state } = useApp();
+  const tenantId = state.tenant;
+
+  const transform = (data: Record<string, unknown>): Record<string, unknown> => {
+    // Citizen must be stamped at the state tenant (user-service upserts
+    // CITIZEN-type users by mobileNumber at the state level).
+    const citizenInput = (data.citizen as Record<string, unknown> | undefined) ?? {};
+    const mobile = typeof citizenInput.mobileNumber === 'string' ? citizenInput.mobileNumber.trim() : '';
+    const stateTenant = tenantId.split('.')[0];
+    const citizen = mobile
+      ? {
+          name: typeof citizenInput.name === 'string' && citizenInput.name ? citizenInput.name : mobile,
+          mobileNumber: mobile,
+          emailId: typeof citizenInput.emailId === 'string' ? citizenInput.emailId : undefined,
+          type: 'CITIZEN',
+          tenantId: stateTenant,
+          roles: [{ code: 'CITIZEN', name: 'Citizen', tenantId: stateTenant }],
+        }
+      : undefined;
+    return { ...data, citizen };
+  };
+
   return (
-    <DigitCreate title="File Complaint" record={{ 'address.city': 'pg' }}>
-      <DigitFormSelect
-        source="serviceCode"
-        label="Complaint Type"
-        reference="complaint-types"
-        optionValue="serviceCode"
-        placeholder="Select complaint type..."
-        validate={v.required}
-      />
-      <DigitFormInput source="description" label="Description" validate={[v.required, v.minLength(10)]} />
-      <DigitFormSelect
-        source="address.locality.code"
-        label="Locality"
-        reference="boundaries"
-        placeholder="Select locality..."
-      />
-      <DigitFormInput source="address.city" label="City" />
+    <DigitCreate title="File Complaint" record={{}} transform={transform}>
+      <FieldSection title="Complaint">
+        <div className="space-y-4">
+          <DigitFormSelect
+            source="serviceCode"
+            label="Complaint Type"
+            reference="complaint-types"
+            optionValue="serviceCode"
+            placeholder="Select complaint type..."
+            validate={v.required}
+          />
+          <DigitFormInput
+            source="description"
+            label="Description"
+            validate={[v.required, v.minLength(10)]}
+            help="What happened? Minimum 10 characters."
+          />
+          <DigitFormSelect
+            source="address.locality.code"
+            label="Locality"
+            reference="boundaries"
+            placeholder="Select locality..."
+            validate={v.required}
+          />
+          <DigitFormInput source="address.landmark" label="Landmark" />
+          <DigitFormInput source="address.pincode" label="Pincode" />
+        </div>
+      </FieldSection>
+
+      <FieldSection title="Citizen">
+        <div className="space-y-4">
+          <DigitFormInput
+            source="citizen.mobileNumber"
+            label="Mobile number"
+            validate={v.required}
+            help="Used to identify the citizen. User-service upserts a CITIZEN account by mobile."
+          />
+          <DigitFormInput
+            source="citizen.name"
+            label="Name"
+            help="Optional. Defaults to the mobile number if left blank."
+          />
+          <DigitFormInput
+            source="citizen.emailId"
+            label="Email"
+            type="email"
+            validate={v.emailOptional}
+          />
+        </div>
+      </FieldSection>
     </DigitCreate>
   );
 }

--- a/src/resources/complaints/ComplaintCreate.tsx
+++ b/src/resources/complaints/ComplaintCreate.tsx
@@ -1,5 +1,6 @@
 import { DigitCreate, DigitFormInput, DigitFormSelect, v } from '@/admin';
 import { FieldSection } from '@/admin/fields';
+import { LocalityPicker } from './LocalityPicker';
 import { useApp } from '../../App';
 
 export function ComplaintCreate() {
@@ -43,12 +44,11 @@ export function ComplaintCreate() {
             validate={[v.required, v.minLength(10)]}
             help="What happened? Minimum 10 characters."
           />
-          <DigitFormSelect
+          <LocalityPicker
             source="address.locality.code"
             label="Locality"
-            reference="boundaries"
-            placeholder="Select locality..."
-            validate={v.required}
+            required
+            help="Cascades from hierarchy → boundary type → locality."
           />
           <DigitFormInput source="address.landmark" label="Landmark" />
           <DigitFormInput source="address.pincode" label="Pincode" />

--- a/src/resources/complaints/ComplaintEdit.tsx
+++ b/src/resources/complaints/ComplaintEdit.tsx
@@ -1,12 +1,14 @@
 import { DigitEdit, DigitFormInput, DigitFormSelect, WorkflowActionSelect } from '@/admin';
 import { FieldSection } from '@/admin/fields';
+import { LocalityPicker } from './LocalityPicker';
 
+// Aligned with the PGR service's server-side source allow-list — probed
+// 2026-04-23 on naipepea: web / mobile / whatsapp accepted; ivr / phone /
+// counter return INVALID_SOURCE. Extend here only after the server list does.
 const SOURCE_CHOICES = [
   { value: 'web', label: 'Web' },
   { value: 'mobile', label: 'Mobile' },
   { value: 'whatsapp', label: 'WhatsApp' },
-  { value: 'ivr', label: 'IVR' },
-  { value: 'counter', label: 'Counter' },
 ];
 
 export function ComplaintEdit() {
@@ -57,12 +59,7 @@ export function ComplaintEdit() {
 
       <FieldSection title="Address">
         <div className="space-y-4">
-          <DigitFormSelect
-            source="address.locality.code"
-            label="Locality"
-            reference="boundaries"
-            placeholder="Select locality..."
-          />
+          <LocalityPicker source="address.locality.code" label="Locality" />
           <DigitFormInput source="address.landmark" label="Landmark" />
           <DigitFormInput source="address.pincode" label="Pincode" />
           <DigitFormInput source="address.street" label="Street" />

--- a/src/resources/complaints/ComplaintEdit.tsx
+++ b/src/resources/complaints/ComplaintEdit.tsx
@@ -63,7 +63,9 @@ export function ComplaintEdit() {
             reference="boundaries"
             placeholder="Select locality..."
           />
-          <DigitFormInput source="address.city" label="City" />
+          <DigitFormInput source="address.landmark" label="Landmark" />
+          <DigitFormInput source="address.pincode" label="Pincode" />
+          <DigitFormInput source="address.street" label="Street" />
         </div>
       </FieldSection>
     </DigitEdit>

--- a/src/resources/complaints/ComplaintList.tsx
+++ b/src/resources/complaints/ComplaintList.tsx
@@ -1,7 +1,50 @@
-import { DigitList, DigitDatagrid } from '@/admin';
+import {
+  DigitList,
+  DigitDatagrid,
+  SearchFilterInput,
+  SelectFilterInput,
+  DateFilterInput,
+  ReferenceFilterInput,
+  TextFilterInput,
+} from '@/admin';
 import type { DigitColumn } from '@/admin';
 import { StatusChip, DateField } from '@/admin/fields';
 import { EntityLink } from '@/components/ui/EntityLink';
+
+// Matches the states in the live `egov-workflow-v2/businessservice` config
+// for PGR on ke.nairobi (probed 2026-04-23).
+const STATUS_CHOICES = [
+  { id: 'PENDINGFORASSIGNMENT', name: 'Pending Assignment' },
+  { id: 'PENDINGFORREASSIGNMENT', name: 'Pending Reassignment' },
+  { id: 'PENDINGATLME', name: 'Pending at LME' },
+  { id: 'PENDINGATSUPERVISOR', name: 'Pending at Supervisor' },
+  { id: 'RESOLVED', name: 'Resolved' },
+  { id: 'RESOLVEDBYSUPERVISOR', name: 'Resolved by Supervisor' },
+  { id: 'REJECTED', name: 'Rejected' },
+  { id: 'CLOSEDAFTERRESOLUTION', name: 'Closed (after resolution)' },
+  { id: 'CLOSEDAFTERREJECTION', name: 'Closed (after rejection)' },
+  { id: 'CANCELLED', name: 'Cancelled' },
+];
+
+const filters = [
+  <SearchFilterInput key="q" source="q" alwaysOn />,
+  <SelectFilterInput
+    key="status"
+    source="applicationStatus"
+    label="Status"
+    choices={STATUS_CHOICES}
+    alwaysOn
+  />,
+  <DateFilterInput key="fromDate" source="fromDate" label="From" />,
+  <DateFilterInput key="toDate" source="toDate" label="To" />,
+  <ReferenceFilterInput
+    key="department"
+    source="additionalDetail.department"
+    reference="departments"
+    label="Department"
+  />,
+  <TextFilterInput key="srid" source="serviceRequestId" label="Request ID" />,
+];
 
 const columns: DigitColumn[] = [
   { source: 'serviceRequestId', label: 'app.fields.request_id' },
@@ -10,7 +53,25 @@ const columns: DigitColumn[] = [
     label: 'app.fields.type',
     render: (record) => {
       const code = String(record.serviceCode ?? '');
-      return code ? <EntityLink resource="complaint-types" id={code} /> : <span className="text-muted-foreground">--</span>;
+      return code ? (
+        <EntityLink resource="complaint-types" id={code} />
+      ) : (
+        <span className="text-muted-foreground">--</span>
+      );
+    },
+  },
+  {
+    source: 'additionalDetail.department',
+    label: 'app.fields.department',
+    sortable: false,
+    render: (record) => {
+      const ad = record.additionalDetail as Record<string, unknown> | undefined;
+      const dept = ad?.department ? String(ad.department) : '';
+      return dept ? (
+        <EntityLink resource="departments" id={dept} />
+      ) : (
+        <span className="text-muted-foreground">--</span>
+      );
     },
   },
   {
@@ -18,7 +79,11 @@ const columns: DigitColumn[] = [
     label: 'app.fields.description',
     render: (record) => {
       const desc = String(record.description ?? '');
-      return <span className="truncate max-w-[200px] block">{desc.length > 60 ? desc.slice(0, 60) + '...' : desc}</span>;
+      return (
+        <span className="truncate max-w-[200px] block">
+          {desc.length > 60 ? desc.slice(0, 60) + '…' : desc}
+        </span>
+      );
     },
   },
   {
@@ -43,7 +108,11 @@ const columns: DigitColumn[] = [
       const address = record.address as Record<string, unknown> | undefined;
       const locality = address?.locality as Record<string, unknown> | undefined;
       const code = String(locality?.code ?? '');
-      return code ? <EntityLink resource="boundaries" id={code} /> : <span className="text-muted-foreground">--</span>;
+      return code ? (
+        <EntityLink resource="boundaries" id={code} />
+      ) : (
+        <span className="text-muted-foreground">--</span>
+      );
     },
   },
   {
@@ -58,7 +127,12 @@ const columns: DigitColumn[] = [
 
 export function ComplaintList() {
   return (
-    <DigitList title="app.resources.complaints" hasCreate sort={{ field: 'auditDetails.createdTime', order: 'DESC' }}>
+    <DigitList
+      title="app.resources.complaints"
+      hasCreate
+      sort={{ field: 'auditDetails.createdTime', order: 'DESC' }}
+      filters={filters}
+    >
       <DigitDatagrid columns={columns} rowClick="show" />
     </DigitList>
   );

--- a/src/resources/complaints/ComplaintShow.tsx
+++ b/src/resources/complaints/ComplaintShow.tsx
@@ -2,7 +2,7 @@ import { DigitShow } from '@/admin';
 import { FieldSection, FieldRow, DateField, StatusChip } from '@/admin/fields';
 import { EntityLink } from '@/components/ui/EntityLink';
 import { useShowController, useGetManyReference } from 'ra-core';
-import { Star } from 'lucide-react';
+import { Star, ExternalLink } from 'lucide-react';
 
 function WorkflowTimeline({ serviceRequestId }: { serviceRequestId: string }) {
   const { data, isPending } = useGetManyReference(
@@ -14,10 +14,10 @@ function WorkflowTimeline({ serviceRequestId }: { serviceRequestId: string }) {
       sort: { field: 'auditDetails.createdTime', order: 'ASC' },
       filter: {},
     },
-    { enabled: !!serviceRequestId }
+    { enabled: !!serviceRequestId },
   );
 
-  if (isPending) return <div className="text-sm text-muted-foreground animate-pulse">Loading timeline...</div>;
+  if (isPending) return <div className="text-sm text-muted-foreground animate-pulse">Loading timeline…</div>;
   if (!data || data.length === 0) return <div className="text-sm text-muted-foreground">No workflow history</div>;
 
   return (
@@ -25,6 +25,7 @@ function WorkflowTimeline({ serviceRequestId }: { serviceRequestId: string }) {
       {data.map((process, i) => {
         const p = process as Record<string, unknown>;
         const audit = p.auditDetails as Record<string, unknown> | undefined;
+        const state = typeof p.state === 'object' ? (p.state as Record<string, unknown>)?.state : p.state;
         return (
           <div key={i} className="flex gap-3 items-start">
             <div className="flex flex-col items-center">
@@ -34,9 +35,11 @@ function WorkflowTimeline({ serviceRequestId }: { serviceRequestId: string }) {
             <div className="pb-4 flex-1">
               <div className="flex items-center gap-2">
                 <span className="text-sm font-medium">{String(p.action ?? '--')}</span>
-                <StatusChip value={p.state} />
+                <StatusChip value={state} />
               </div>
-              {p.comment != null && <p className="text-sm text-muted-foreground mt-1">{String(p.comment)}</p>}
+              {p.comment != null && (
+                <p className="text-sm text-muted-foreground mt-1">{String(p.comment)}</p>
+              )}
               <div className="text-xs text-muted-foreground mt-1">
                 <DateField value={audit?.createdTime} />
               </div>
@@ -63,6 +66,25 @@ function RatingStars({ rating }: { rating: unknown }) {
   );
 }
 
+function GeoLocationLink({ lat, lng }: { lat: unknown; lng: unknown }) {
+  const latN = Number(lat);
+  const lngN = Number(lng);
+  if (!Number.isFinite(latN) || !Number.isFinite(lngN) || (latN === 0 && lngN === 0)) {
+    return <span className="text-muted-foreground">--</span>;
+  }
+  return (
+    <a
+      href={`https://www.google.com/maps?q=${latN},${lngN}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-primary hover:underline"
+    >
+      {latN.toFixed(6)}, {lngN.toFixed(6)}
+      <ExternalLink className="w-3 h-3" />
+    </a>
+  );
+}
+
 export function ComplaintShow() {
   const { record } = useShowController();
 
@@ -72,19 +94,36 @@ export function ComplaintShow() {
         const citizen = rec.citizen as Record<string, unknown> | undefined;
         const address = rec.address as Record<string, unknown> | undefined;
         const locality = address?.locality as Record<string, unknown> | undefined;
+        const geo = address?.geoLocation as Record<string, unknown> | undefined;
         const audit = rec.auditDetails as Record<string, unknown> | undefined;
+        const additional = rec.additionalDetail as Record<string, unknown> | undefined;
 
         return (
           <div className="space-y-6">
             <FieldSection title="Header">
               <FieldRow label="Request ID">{String(rec.serviceRequestId ?? '')}</FieldRow>
-              <FieldRow label="Status"><StatusChip value={rec.applicationStatus} /></FieldRow>
-              <FieldRow label="Rating"><RatingStars rating={rec.rating} /></FieldRow>
+              <FieldRow label="Status">
+                <StatusChip value={rec.applicationStatus} />
+              </FieldRow>
+              <FieldRow label="Rating">
+                <RatingStars rating={rec.rating} />
+              </FieldRow>
             </FieldSection>
 
             <FieldSection title="Details">
               <FieldRow label="Type">
-                {rec.serviceCode ? <EntityLink resource="complaint-types" id={String(rec.serviceCode)} /> : '--'}
+                {rec.serviceCode ? (
+                  <EntityLink resource="complaint-types" id={String(rec.serviceCode)} />
+                ) : (
+                  '--'
+                )}
+              </FieldRow>
+              <FieldRow label="Department">
+                {additional?.department ? (
+                  <EntityLink resource="departments" id={String(additional.department)} />
+                ) : (
+                  <span className="text-muted-foreground">--</span>
+                )}
               </FieldRow>
               <FieldRow label="Description">{String(rec.description ?? '')}</FieldRow>
               <FieldRow label="Source">{String(rec.source ?? '--')}</FieldRow>
@@ -97,20 +136,31 @@ export function ComplaintShow() {
 
             <FieldSection title="Address">
               <FieldRow label="Locality">
-                {locality?.code ? <EntityLink resource="boundaries" id={String(locality.code)} /> : '--'}
+                {locality?.code ? (
+                  <EntityLink resource="boundaries" id={String(locality.code)} />
+                ) : (
+                  '--'
+                )}
               </FieldRow>
-              <FieldRow label="City">{String(address?.city ?? '--')}</FieldRow>
+              <FieldRow label="Landmark">{String(address?.landmark ?? '--')}</FieldRow>
+              <FieldRow label="Street">{String(address?.street ?? '--')}</FieldRow>
+              <FieldRow label="Pincode">{String(address?.pincode ?? '--')}</FieldRow>
+              <FieldRow label="Geo">
+                <GeoLocationLink lat={geo?.latitude} lng={geo?.longitude} />
+              </FieldRow>
             </FieldSection>
 
             <FieldSection title="Workflow Timeline">
-              <WorkflowTimeline
-                serviceRequestId={String(rec.serviceRequestId ?? '')}
-              />
+              <WorkflowTimeline serviceRequestId={String(rec.serviceRequestId ?? '')} />
             </FieldSection>
 
             <FieldSection title="Audit">
-              <FieldRow label="Created"><DateField value={audit?.createdTime} /></FieldRow>
-              <FieldRow label="Last Modified"><DateField value={audit?.lastModifiedTime} /></FieldRow>
+              <FieldRow label="Created">
+                <DateField value={audit?.createdTime} />
+              </FieldRow>
+              <FieldRow label="Last Modified">
+                <DateField value={audit?.lastModifiedTime} />
+              </FieldRow>
             </FieldSection>
           </div>
         );

--- a/src/resources/complaints/ComplaintShow.tsx
+++ b/src/resources/complaints/ComplaintShow.tsx
@@ -130,7 +130,25 @@ export function ComplaintShow() {
             </FieldSection>
 
             <FieldSection title="Citizen">
-              <FieldRow label="Name">{String(citizen?.name ?? '--')}</FieldRow>
+              <FieldRow label="Name">
+                {(() => {
+                  const name = citizen?.name ? String(citizen.name) : '';
+                  const mobile = citizen?.mobileNumber ? String(citizen.mobileNumber) : '';
+                  if (!name) return <span className="text-muted-foreground">--</span>;
+                  // When the citizen registered via mobile-only OTP, the
+                  // user-service sets `name = mobileNumber`. Flag that so
+                  // operators don't mistake a phone number for a real name.
+                  if (name === mobile) {
+                    return (
+                      <span>
+                        {name}{' '}
+                        <span className="text-xs text-muted-foreground">(mobile-only account)</span>
+                      </span>
+                    );
+                  }
+                  return name;
+                })()}
+              </FieldRow>
               <FieldRow label="Mobile">{String(citizen?.mobileNumber ?? '--')}</FieldRow>
             </FieldSection>
 

--- a/src/resources/complaints/LocalityPicker.tsx
+++ b/src/resources/complaints/LocalityPicker.tsx
@@ -1,0 +1,224 @@
+import { useMemo } from 'react';
+import { useInput, useGetList, type RaRecord } from 'ra-core';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+
+interface HierarchyLevel {
+  boundaryType: string;
+  parentBoundaryType?: string | null;
+  active?: boolean;
+}
+
+interface HierarchyRecord extends RaRecord {
+  hierarchyType: string;
+  boundaryHierarchy?: HierarchyLevel[];
+}
+
+interface BoundaryRecord extends RaRecord {
+  code: string;
+  name?: string;
+  boundaryType: string;
+  hierarchyType?: string;
+  parentCode?: string;
+}
+
+export interface LocalityPickerProps {
+  /** Form path for the boundary CODE (typically `address.locality.code`). */
+  source?: string;
+  label?: string;
+  help?: string;
+  /** When true, the field is required for validation. */
+  required?: boolean;
+}
+
+/** Single-select cascading locality picker: hierarchy → boundaryType → boundary.
+ *  Writes only the selected boundary's `code` to the form. Hierarchy and type
+ *  choices live in local state — they're navigation, not data.
+ *
+ *  Mirrors `JurisdictionEditor`'s index scheme but emits a flat string for
+ *  PGR's `address.locality.code` shape. */
+export function LocalityPicker({
+  source = 'address.locality.code',
+  label = 'Locality',
+  help,
+  required,
+}: LocalityPickerProps) {
+  const { id, field, fieldState } = useInput({ source, validate: required ? requiredV : undefined });
+
+  const { data: hierarchies, isLoading: hierarchiesLoading } = useGetList<HierarchyRecord>(
+    'boundary-hierarchies',
+    { pagination: { page: 1, perPage: 100 }, sort: { field: 'hierarchyType', order: 'ASC' } },
+  );
+
+  const { data: boundaries, isLoading: boundariesLoading } = useGetList<BoundaryRecord>(
+    'boundaries',
+    { pagination: { page: 1, perPage: 1000 }, sort: { field: 'name', order: 'ASC' } },
+  );
+
+  // Seed the navigation selects from the *current* boundary code (if the form
+  // loaded an existing complaint). We look up the boundary record and back out
+  // its hierarchy + boundaryType so the selects display the right ancestors.
+  const currentBoundary = useMemo<BoundaryRecord | undefined>(() => {
+    const code = field.value;
+    if (!code || typeof code !== 'string') return undefined;
+    return (boundaries ?? []).find((b) => b.code === code);
+  }, [field.value, boundaries]);
+
+  const hierarchyChoices = useMemo(() => {
+    if (!hierarchies) return [] as { value: string; label: string }[];
+    return hierarchies.map((h) => ({ value: h.hierarchyType, label: h.hierarchyType }));
+  }, [hierarchies]);
+
+  const boundaryTypesByHierarchy = useMemo(() => {
+    const map = new Map<string, string[]>();
+    if (!hierarchies) return map;
+    for (const h of hierarchies) {
+      const seen = new Set<string>();
+      const types: string[] = [];
+      for (const lvl of h.boundaryHierarchy ?? []) {
+        if (!lvl || lvl.active === false) continue;
+        if (!lvl.boundaryType || seen.has(lvl.boundaryType)) continue;
+        seen.add(lvl.boundaryType);
+        types.push(lvl.boundaryType);
+      }
+      map.set(h.hierarchyType, types);
+    }
+    return map;
+  }, [hierarchies]);
+
+  const boundaryIndex = useMemo(() => {
+    const byHierarchy = new Map<string, Map<string, BoundaryRecord[]>>();
+    const byTypeOnly = new Map<string, BoundaryRecord[]>();
+    for (const b of boundaries ?? []) {
+      if (!b.boundaryType) continue;
+      const listByType = byTypeOnly.get(b.boundaryType) ?? [];
+      listByType.push(b);
+      byTypeOnly.set(b.boundaryType, listByType);
+      if (b.hierarchyType) {
+        const inner = byHierarchy.get(b.hierarchyType) ?? new Map<string, BoundaryRecord[]>();
+        const arr = inner.get(b.boundaryType) ?? [];
+        arr.push(b);
+        inner.set(b.boundaryType, arr);
+        byHierarchy.set(b.hierarchyType, inner);
+      }
+    }
+    return { byHierarchy, byTypeOnly };
+  }, [boundaries]);
+
+  // Local navigation state — derived from the loaded value or defaults.
+  const hierarchyType =
+    currentBoundary?.hierarchyType ?? hierarchyChoices[0]?.value ?? '';
+  const boundaryType =
+    currentBoundary?.boundaryType ??
+    (boundaryTypesByHierarchy.get(hierarchyType) ?? [])[0] ??
+    '';
+
+  // Navigation state that the operator *actually* manipulates: we keep the
+  // hierarchy + type in form-local sidecars so changing them doesn't fire an
+  // immediate `field.onChange` of a broken code.
+  const { hSource, tSource } = {
+    hSource: `${source}__h`,
+    tSource: `${source}__t`,
+  };
+  const hInput = useInput({ source: hSource, defaultValue: hierarchyType });
+  const tInput = useInput({ source: tSource, defaultValue: boundaryType });
+  const activeHierarchy = String(hInput.field.value || hierarchyType);
+  const activeType = String(tInput.field.value || boundaryType);
+
+  const typesForHierarchy =
+    boundaryTypesByHierarchy.get(activeHierarchy) ?? [];
+
+  const boundaryOptions = useMemo<BoundaryRecord[]>(() => {
+    if (!activeType) return [];
+    const inner = boundaryIndex.byHierarchy.get(activeHierarchy);
+    if (inner && inner.size > 0) return inner.get(activeType) ?? [];
+    return boundaryIndex.byTypeOnly.get(activeType) ?? [];
+  }, [boundaryIndex, activeHierarchy, activeType]);
+
+  const hasError = fieldState.invalid && fieldState.isTouched;
+  const errorMessage = fieldState.error?.message;
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+          {required && <span className="text-destructive ml-0.5">*</span>}
+        </Label>
+      )}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+        <Select
+          value={activeHierarchy}
+          onValueChange={(v) => {
+            hInput.field.onChange(v);
+            tInput.field.onChange('');
+            field.onChange('');
+          }}
+          disabled={hierarchiesLoading}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder={hierarchiesLoading ? 'Loading…' : 'Hierarchy'} />
+          </SelectTrigger>
+          <SelectContent>
+            {hierarchyChoices.map((c) => (
+              <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={activeType}
+          onValueChange={(v) => {
+            tInput.field.onChange(v);
+            field.onChange('');
+          }}
+          disabled={!activeHierarchy || typesForHierarchy.length === 0}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Boundary Type" />
+          </SelectTrigger>
+          <SelectContent>
+            {typesForHierarchy.map((t) => (
+              <SelectItem key={t} value={t}>{t}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={typeof field.value === 'string' ? field.value : ''}
+          onValueChange={(v) => field.onChange(v)}
+          disabled={!activeType || boundariesLoading}
+        >
+          <SelectTrigger
+            id={id}
+            aria-invalid={hasError || undefined}
+            className={hasError ? 'border-destructive focus-visible:ring-destructive' : ''}
+          >
+            <SelectValue placeholder={boundariesLoading ? 'Loading…' : 'Boundary'} />
+          </SelectTrigger>
+          <SelectContent>
+            {boundaryOptions.map((b) => (
+              <SelectItem key={b.code} value={b.code}>
+                {b.name ?? b.code}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {hasError && errorMessage && (
+        <p className="mt-1 text-xs text-destructive" role="alert">{errorMessage}</p>
+      )}
+      {!hasError && help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}
+
+function requiredV(value: unknown): string | undefined {
+  return value === undefined || value === null || value === '' ? 'Required' : undefined;
+}


### PR DESCRIPTION
Builds on #7 and #8.

## Summary

Polish pass after the edit-correctness fix (#7) and the data-surface pass (#8). Operator-facing UX tightening grounded in live probes.

### Cascading locality picker

Flat 85-item `<DigitFormSelect reference="boundaries">` replaced with a 3-step cascading picker: **hierarchy → boundaryType → boundary**. Writes just the leaf `code` to `address.locality.code` — the shape PGR's `_create` / `_update` already expect.

Same index scheme as `JurisdictionEditor`, single-select instead of multi-row.

Wired into `ComplaintCreate` (required) and `ComplaintEdit`.

### Full 11-state workflow awareness

`WorkflowActionSelect` fixes:

- **`action.nextState` UUID bug** — the workflow config stores `nextState` as a state UUID, not an applicationStatus label. The "→ next-state" hint in the dropdown was rendering raw 36-char hex. Added a uuid→applicationStatus lookup from `workflowDef.states[]` so operators see "→ Pending at LME" instead of `9cb684b4-2a7b-4725-81e4-…`.
- `ACTION_LABELS` superset of live PGR vocabulary — added ESCALATE, COMMENT, SLA_ESCALATE alongside the existing seven.
- `STATE_LABELS` covers the full 11-state machine — PENDINGATSUPERVISOR, RESOLVEDBYSUPERVISOR, CANCELLED added.

### Source allow-list tightened

Live-probed `_create` with each candidate source:
| Source | Server response |
|---|---|
| `web` | ✅ accepted |
| `mobile` | ✅ accepted |
| `whatsapp` | ✅ accepted |
| `ivr` | ❌ `INVALID_SOURCE` |
| `phone` | ❌ `INVALID_SOURCE` |
| `counter` | ❌ `INVALID_SOURCE` |

`ComplaintEdit` `SOURCE_CHOICES` dropped to the three server-accepted values. Comment documents the probe + rule for extending.

### Mobile-only citizen display

On `ComplaintShow`, when `citizen.name === citizen.mobileNumber` (user-service sets `name = mobileNumber` on first mobile-OTP registration), the Name row renders `"711111111 (mobile-only account)"`. Subtle but saves operators from misreading a phone number as a name.

## API shape validation

- `businessservice/_search` full state machine probed: 11 states, 10 distinct actions (`APPLY, ASSIGN, COMMENT, ESCALATE, RATE, REASSIGN, REJECT, REOPEN, RESOLVE, SLA_ESCALATE`). All covered by labels.
- Source acceptance probed across 6 candidates — 3 accepted, 3 rejected with `INVALID_SOURCE`.
- Probe complaints (`PG-PGR-2026-04-23-004420`, `-004421`, `-004422`) terminated via `REJECT` after testing. No active probe data.

## Files

- `src/resources/complaints/LocalityPicker.tsx` — new single-select cascading picker.
- `src/admin/WorkflowActionSelect.tsx` — uuid→status map, extended labels.
- `src/resources/complaints/ComplaintCreate.tsx` — LocalityPicker wiring.
- `src/resources/complaints/ComplaintEdit.tsx` — LocalityPicker + tightened sources.
- `src/resources/complaints/ComplaintShow.tsx` — mobile-only citizen heuristic.

## Testing plan

- [ ] File a complaint from `/manage/complaints/create`. The Locality row shows three selects; picking hierarchy enables boundary-type; picking type enables the boundary list, filtered to the right subset.
- [ ] Open an existing complaint in Edit. Workflow action dropdown shows "→ Pending at LME" style hints, not UUIDs.
- [ ] Try setting source to each of `web / mobile / whatsapp` — saves cleanly. `ivr` / `counter` are no longer offered in the dropdown.
- [ ] Open a mobile-OTP-registered citizen's complaint on Show — Name renders with `(mobile-only account)` suffix.

## Clash analysis

- Sequenced after #7 (edit correctness) and #8 (data surfaces). Locality changes in this PR rely on the merge-update path from #7 to persist.
- No overlap with HRMS / dept-desig workstreams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)