### PR TITLE
boundary-hierarchies: Create form + aggregate sub-tenants + richer Show

### DIFF
--- a/packages/data-provider/src/client/DigitApiClient.ts
+++ b/packages/data-provider/src/client/DigitApiClient.ts
@@ -311,11 +311,20 @@ export class DigitApiClient {
   }
 
   async boundaryHierarchyCreate(tenantId: string, hierarchyType: string, levels: { boundaryType: string; parentBoundaryType: string | null }[]): Promise<Record<string, unknown>> {
-    const data = await this.request<{ BoundaryHierarchy?: Record<string, unknown> }>(this.endpoint('BOUNDARY_HIERARCHY_CREATE'), {
-      RequestInfo: this.buildRequestInfo(),
-      BoundaryHierarchy: { tenantId, hierarchyType, boundaryHierarchy: levels.map((h) => ({ ...h, active: true })) },
-    });
-    return data.BoundaryHierarchy || {};
+    // Server wraps the created record in a single-element *array* under
+    // `BoundaryHierarchy` despite the request side being a single object.
+    // Accept both shapes so we don't break if a future service version
+    // reverts to the singular form.
+    const data = await this.request<{ BoundaryHierarchy?: Record<string, unknown> | Record<string, unknown>[] }>(
+      this.endpoint('BOUNDARY_HIERARCHY_CREATE'),
+      {
+        RequestInfo: this.buildRequestInfo(),
+        BoundaryHierarchy: { tenantId, hierarchyType, boundaryHierarchy: levels.map((h) => ({ ...h, active: true })) },
+      },
+    );
+    const bh = data.BoundaryHierarchy;
+    if (Array.isArray(bh)) return bh[0] ?? {};
+    return bh ?? {};
   }
 
   async boundaryRelationshipCreate(tenantId: string, code: string, hierarchyType: string, boundaryType: string, parent: string | null): Promise<Record<string, unknown>> {

--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -271,8 +271,25 @@ async function mdmsSchemaGetList(client: DigitApiClient, config: ResourceConfig,
 }
 
 async function boundaryHierarchyGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string): Promise<RaRecord[]> {
-  const hierarchies = await client.boundaryHierarchySearch(tenantId);
-  return hierarchies.map((h) => normalizeRecord(h, config));
+  // Fetch the session tenant's hierarchies first. When at state level,
+  // aggregate city-tenant hierarchies too — the boundary service stores each
+  // tenant's definition separately (no cross-tenant inheritance) so a
+  // ke.nairobi ADMIN hierarchy is invisible from a ke session otherwise.
+  const rootHierarchies = await client.boundaryHierarchySearch(tenantId).catch(() => []);
+  let all = rootHierarchies;
+  if (!tenantId.includes('.')) {
+    const tenantRecords = await client.mdmsSearch(tenantId, 'tenant.tenants', { limit: 200 });
+    const cityTenants = tenantRecords
+      .filter((r) => r.isActive && r.data?.code && String(r.data.code).startsWith(`${tenantId}.`))
+      .map((r) => String(r.data.code));
+    if (cityTenants.length > 0) {
+      const cityResults = await Promise.all(
+        cityTenants.map((ct) => client.boundaryHierarchySearch(ct).catch(() => [])),
+      );
+      all = [...rootHierarchies, ...cityResults.flat()];
+    }
+  }
+  return all.map((h) => normalizeRecord(h, config));
 }
 
 // --- Factory ---
@@ -532,6 +549,29 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         const data = params.data as Record<string, unknown>;
         const user = await client.userCreate(data, tenantId);
         return { data: normalizeRecord(user, config) };
+      }
+      if (config.type === 'boundary-hierarchy') {
+        const data = params.data as Record<string, unknown>;
+        const hierarchyType = String(data.hierarchyType ?? '').trim();
+        if (!hierarchyType) throw new Error('hierarchyType is required');
+        const levelsInput = Array.isArray(data.boundaryHierarchy) ? data.boundaryHierarchy : [];
+        const levels = levelsInput
+          .map((lvl) => lvl as Record<string, unknown>)
+          .filter((lvl) => typeof lvl?.boundaryType === 'string' && (lvl.boundaryType as string).trim())
+          .map((lvl) => ({
+            boundaryType: String(lvl.boundaryType).trim(),
+            parentBoundaryType:
+              typeof lvl.parentBoundaryType === 'string' && lvl.parentBoundaryType.trim()
+                ? lvl.parentBoundaryType.trim()
+                : null,
+          }));
+        if (levels.length === 0) throw new Error('At least one hierarchy level is required');
+        const created = await client.boundaryHierarchyCreate(
+          tenantId,
+          hierarchyType,
+          levels,
+        );
+        return { data: normalizeRecord(created, config) };
       }
       throw new Error(`Create not supported for resource type: ${config.type}`);
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,7 +26,7 @@ import {
   WorkflowServiceList, WorkflowServiceShow,
   WorkflowProcessList, WorkflowProcessShow,
   MdmsSchemaList, MdmsSchemaShow,
-  BoundaryHierarchyList, BoundaryHierarchyShow,
+  BoundaryHierarchyList, BoundaryHierarchyShow, BoundaryHierarchyCreate,
   AdvancedPage,
 } from '@/resources';
 import PgrDashboard from './pages/PgrDashboard';
@@ -110,7 +110,7 @@ function ManagementAdmin() {
         <Resource name="workflow-business-services" list={WorkflowServiceList} show={WorkflowServiceShow} />
         <Resource name="workflow-processes" list={WorkflowProcessList} show={WorkflowProcessShow} />
         <Resource name="mdms-schemas" list={MdmsSchemaList} show={MdmsSchemaShow} />
-        <Resource name="boundary-hierarchies" list={BoundaryHierarchyList} show={BoundaryHierarchyShow} />
+        <Resource name="boundary-hierarchies" list={BoundaryHierarchyList} show={BoundaryHierarchyShow} create={BoundaryHierarchyCreate} />
 
         {/* Generic MDMS with Show/Edit/Create (exclude resources with dedicated UI above) */}
         {Object.keys(getGenericMdmsResources()).filter((name) => name !== 'role-actions').map((name) => (

--- a/src/resources/boundary-hierarchies/BoundaryHierarchyCreate.tsx
+++ b/src/resources/boundary-hierarchies/BoundaryHierarchyCreate.tsx
@@ -1,0 +1,31 @@
+import { DigitCreate, DigitFormInput, v } from '@/admin';
+import { FieldSection } from '@/admin/fields';
+import { HierarchyLevelEditor } from './HierarchyLevelEditor';
+
+/** Create a boundary hierarchy on the session tenant. Immutable after
+ *  creation — the `boundary-hierarchy-definition` service exposes only
+ *  `_search` and `_create`; `_update` / `_delete` both return 400. Surface
+ *  a single-shot Create only; do not register Edit or Delete. */
+export function BoundaryHierarchyCreate() {
+  return (
+    <DigitCreate
+      title="Create Boundary Hierarchy"
+      record={{ boundaryHierarchy: [{ boundaryType: '', parentBoundaryType: null }] }}
+    >
+      <FieldSection title="Details">
+        <DigitFormInput
+          source="hierarchyType"
+          label="Hierarchy Type"
+          validate={v.codeRequired}
+          help="Short uppercase identifier, e.g. ADMIN, REVENUE, ELECTION. One per tenant per type."
+        />
+      </FieldSection>
+
+      <FieldSection title="Levels">
+        <HierarchyLevelEditor
+          help="First row is the root (no parent). Each subsequent row's parent must reference a boundaryType defined in an earlier row."
+        />
+      </FieldSection>
+    </DigitCreate>
+  );
+}

--- a/src/resources/boundary-hierarchies/BoundaryHierarchyList.tsx
+++ b/src/resources/boundary-hierarchies/BoundaryHierarchyList.tsx
@@ -1,14 +1,50 @@
-import { DigitList, DigitDatagrid } from '@/admin';
+import {
+  DigitList,
+  DigitDatagrid,
+  SearchFilterInput,
+  SelectFilterInput,
+} from '@/admin';
 import type { DigitColumn } from '@/admin';
+
+const filters = [
+  <SearchFilterInput key="q" source="q" alwaysOn />,
+  <SelectFilterInput
+    key="tenantId"
+    source="tenantId"
+    label="Tenant"
+    // Choices are populated at render time in future work; for now the
+    // Search input covers tenant filtering via substring match.
+    choices={[]}
+  />,
+];
 
 const columns: DigitColumn[] = [
   { source: 'hierarchyType', label: 'app.fields.hierarchy_type' },
   { source: 'tenantId', label: 'app.fields.tenant' },
+  {
+    source: 'boundaryHierarchy',
+    label: 'app.fields.levels',
+    sortable: false,
+    render: (record) => {
+      const levels = record.boundaryHierarchy as Array<Record<string, unknown>> | undefined;
+      if (!levels || levels.length === 0) return <span className="text-muted-foreground">--</span>;
+      return (
+        <span className="font-mono text-xs">
+          {levels.map((l) => String(l.boundaryType ?? '?')).join(' → ')}
+        </span>
+      );
+    },
+  },
 ];
 
 export function BoundaryHierarchyList() {
   return (
-    <DigitList title="app.resources.boundary_hierarchies" sort={{ field: 'hierarchyType', order: 'ASC' }}>
+    <DigitList
+      title="app.resources.boundary_hierarchies"
+      hasCreate
+      sort={{ field: 'hierarchyType', order: 'ASC' }}
+      filters={filters}
+    >
       <DigitDatagrid columns={columns} rowClick="show" />
     </DigitList>
   );

--- a/src/resources/boundary-hierarchies/BoundaryHierarchyShow.tsx
+++ b/src/resources/boundary-hierarchies/BoundaryHierarchyShow.tsx
@@ -1,5 +1,5 @@
 import { DigitShow } from '@/admin';
-import { FieldSection, FieldRow } from '@/admin/fields';
+import { FieldSection, FieldRow, DateField } from '@/admin/fields';
 import { EntityLink } from '@/components/ui/EntityLink';
 import { Badge } from '@/components/ui/badge';
 import { ArrowDown } from 'lucide-react';
@@ -12,6 +12,8 @@ export function BoundaryHierarchyShow() {
     <DigitShow title={record ? `Hierarchy: ${record.hierarchyType ?? record.id}` : 'Boundary Hierarchy'}>
       {(rec: Record<string, unknown>) => {
         const levels = rec.boundaryHierarchy as Array<Record<string, unknown>> | undefined;
+        const audit = rec.auditDetails as Record<string, unknown> | undefined;
+        const inactiveCount = (levels ?? []).filter((l) => l.active === false).length;
 
         return (
           <div className="space-y-6">
@@ -25,19 +27,58 @@ export function BoundaryHierarchyShow() {
             {levels && levels.length > 0 && (
               <FieldSection title="Hierarchy Levels">
                 <div className="flex flex-col items-start gap-1">
-                  {levels.map((level, i) => (
-                    <div key={i} className="flex flex-col items-start">
-                      <Badge variant="outline" className="text-xs">
-                        {String(level.boundaryType ?? level.parentBoundaryType ?? `Level ${i + 1}`)}
-                      </Badge>
-                      {i < levels.length - 1 && (
-                        <div className="flex items-center ml-3 my-0.5">
-                          <ArrowDown className="w-3 h-3 text-muted-foreground" />
+                  {levels.map((level, i) => {
+                    const boundaryType = String(level.boundaryType ?? level.parentBoundaryType ?? `Level ${i + 1}`);
+                    const isInactive = level.active === false;
+                    const parent = level.parentBoundaryType ? String(level.parentBoundaryType) : null;
+                    return (
+                      <div key={i} className="flex flex-col items-start">
+                        <div className="flex items-center gap-2">
+                          <Badge
+                            variant="outline"
+                            className={
+                              'text-xs ' +
+                              (isInactive ? 'line-through text-muted-foreground opacity-60' : '')
+                            }
+                          >
+                            {boundaryType}
+                          </Badge>
+                          {isInactive && (
+                            <span className="text-xs text-muted-foreground">(inactive)</span>
+                          )}
+                          {parent && i > 0 && parent !== String(levels[i - 1]?.boundaryType ?? '') && (
+                            <span className="text-xs text-amber-600" title="Parent breaks the linear chain">
+                              ⚠ parent = {parent}
+                            </span>
+                          )}
                         </div>
-                      )}
-                    </div>
-                  ))}
+                        {i < levels.length - 1 && (
+                          <div className="flex items-center ml-3 my-0.5">
+                            <ArrowDown className="w-3 h-3 text-muted-foreground" />
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
+                {inactiveCount > 0 && (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    {inactiveCount} inactive level{inactiveCount === 1 ? '' : 's'}.
+                  </p>
+                )}
+              </FieldSection>
+            )}
+
+            {audit && (
+              <FieldSection title="Audit">
+                <FieldRow label="Created by">{String(audit.createdBy ?? '--')}</FieldRow>
+                <FieldRow label="Created at">
+                  <DateField value={audit.createdTime} />
+                </FieldRow>
+                <FieldRow label="Last modified by">{String(audit.lastModifiedBy ?? '--')}</FieldRow>
+                <FieldRow label="Last modified at">
+                  <DateField value={audit.lastModifiedTime} />
+                </FieldRow>
               </FieldSection>
             )}
           </div>

--- a/src/resources/boundary-hierarchies/HierarchyLevelEditor.tsx
+++ b/src/resources/boundary-hierarchies/HierarchyLevelEditor.tsx
@@ -1,0 +1,184 @@
+import { useMemo } from 'react';
+import { useInput } from 'ra-core';
+import { Plus, Trash2 } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select';
+
+interface Level {
+  boundaryType: string;
+  parentBoundaryType: string | null;
+}
+
+export interface HierarchyLevelEditorProps {
+  source?: string;
+  label?: string;
+  help?: string;
+}
+
+/** Multi-row editor for a boundary hierarchy's levels. Each row captures a
+ *  boundaryType and its parent. The parent dropdown for row N is limited to
+ *  earlier rows — enforcing a strictly-linear chain — with the first row
+ *  locked at parent = null (root of the tree).
+ *
+ *  The boundary-hierarchy `_create` endpoint expects an array
+ *  `boundaryHierarchy: [{boundaryType, parentBoundaryType, active}]`. This
+ *  editor writes that shape; the data-provider stamps `active: true`. */
+export function HierarchyLevelEditor({
+  source = 'boundaryHierarchy',
+  label = 'Hierarchy Levels',
+  help,
+}: HierarchyLevelEditorProps) {
+  const { id, field } = useInput({ source });
+
+  const rows: Level[] = useMemo(() => {
+    if (!Array.isArray(field.value)) return [];
+    return (field.value as unknown[]).map((v) => {
+      const r = (v && typeof v === 'object' ? v : {}) as Record<string, unknown>;
+      return {
+        boundaryType: typeof r.boundaryType === 'string' ? r.boundaryType : '',
+        parentBoundaryType:
+          typeof r.parentBoundaryType === 'string' && r.parentBoundaryType
+            ? r.parentBoundaryType
+            : null,
+      };
+    });
+  }, [field.value]);
+
+  const write = (next: Level[]) => field.onChange(next);
+
+  const updateRow = (index: number, patch: Partial<Level>) => {
+    const next = rows.slice();
+    next[index] = { ...next[index], ...patch };
+    write(next);
+  };
+
+  const addRow = () => {
+    const last = rows[rows.length - 1];
+    write([
+      ...rows,
+      {
+        boundaryType: '',
+        // First row has no parent; later rows default to chaining off the
+        // previous row so the hierarchy stays linear by default.
+        parentBoundaryType: rows.length === 0 ? null : last?.boundaryType || null,
+      },
+    ]);
+  };
+
+  const removeRow = (index: number) => {
+    const next = rows.slice();
+    next.splice(index, 1);
+    // If we removed a row other rows reference as their parent, coerce any
+    // dangling references to null so the server doesn't get a broken chain.
+    const known = new Set(next.map((r) => r.boundaryType).filter(Boolean));
+    for (const r of next) {
+      if (r.parentBoundaryType && !known.has(r.parentBoundaryType)) {
+        r.parentBoundaryType = null;
+      }
+    }
+    write(next);
+  };
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id} className="mb-1.5 block text-sm font-medium text-foreground">
+          {label}
+        </Label>
+      )}
+
+      {rows.length === 0 ? (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-dashed p-3">
+          <p className="text-sm text-muted-foreground">No levels yet</p>
+          <Button type="button" variant="outline" size="sm" onClick={addRow}>
+            <Plus className="w-4 h-4" />
+            Add level
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {rows.map((row, index) => {
+            const parentChoices = rows
+              .slice(0, index)
+              .map((r) => r.boundaryType)
+              .filter((t) => t);
+            return (
+              <div key={index} className="relative border rounded p-3 pr-10 bg-muted/30">
+                <button
+                  type="button"
+                  onClick={() => removeRow(index)}
+                  aria-label={`Remove level ${index + 1}`}
+                  className="absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <div>
+                    <Label className="mb-1.5 block text-xs font-medium text-foreground">
+                      Boundary Type
+                    </Label>
+                    <Input
+                      type="text"
+                      value={row.boundaryType}
+                      onChange={(e) => updateRow(index, { boundaryType: e.target.value })}
+                      placeholder="e.g. County"
+                    />
+                  </div>
+                  <div>
+                    <Label className="mb-1.5 block text-xs font-medium text-foreground">
+                      Parent Boundary Type
+                    </Label>
+                    {index === 0 ? (
+                      <Input type="text" disabled value="(root — no parent)" />
+                    ) : (
+                      <Select
+                        value={row.parentBoundaryType ?? ''}
+                        onValueChange={(v) =>
+                          updateRow(index, { parentBoundaryType: v || null })
+                        }
+                        disabled={parentChoices.length === 0}
+                      >
+                        <SelectTrigger>
+                          <SelectValue
+                            placeholder={
+                              parentChoices.length === 0
+                                ? 'Fill earlier rows first'
+                                : 'Select parent…'
+                            }
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {parentChoices.map((p) => (
+                            <SelectItem key={p} value={p}>
+                              {p}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+          <div>
+            <Button type="button" variant="outline" size="sm" onClick={addRow}>
+              <Plus className="w-4 h-4" />
+              Add level
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {help && <p className="mt-1 text-xs text-muted-foreground">{help}</p>}
+    </div>
+  );
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -50,3 +50,4 @@ export { MdmsSchemaList } from './mdms-schemas/MdmsSchemaList';
 export { MdmsSchemaShow } from './mdms-schemas/MdmsSchemaShow';
 export { BoundaryHierarchyList } from './boundary-hierarchies/BoundaryHierarchyList';
 export { BoundaryHierarchyShow } from './boundary-hierarchies/BoundaryHierarchyShow';
+export { BoundaryHierarchyCreate } from './boundary-hierarchies/BoundaryHierarchyCreate';


### PR DESCRIPTION
## Summary

Adds a post-onboarding Create path for boundary hierarchies, aggregates sub-tenant hierarchies at state scope, and surfaces per-level `active` state + audit details on Show.

### Why

- Phase 2 onboarding seeds one hierarchy per tenant. Post-go-live, adding a new one (`ELECTION`, `REVENUE`) required re-running the wizard or a raw API call — no `/manage` path existed.
- State-level operators couldn't see city-tenant hierarchies at all — data-provider only queried the session tenant.
- Show page ignored `auditDetails` and treated inactive levels identically to active ones.

### Hard constraint discovered by probing

`POST /boundary-service/boundary-hierarchy-definition/_update` → `NoResourceFoundException 400`.
`POST /boundary-service/boundary-hierarchy-definition/_delete` → `NoResourceFoundException 400`.

**Hierarchies are immutable after creation on the server side.** Only `_search` and `_create` are exposed. We deliberately do not register Edit or Delete in `App.tsx`; a code comment in `BoundaryHierarchyCreate` documents why.

## Changes

| Area | File | Change |
|---|---|---|
| Create form | `src/resources/boundary-hierarchies/BoundaryHierarchyCreate.tsx` | New. hierarchyType + levels editor. |
| Level editor | `src/resources/boundary-hierarchies/HierarchyLevelEditor.tsx` | New. Multi-row with parent dropdown scoped to earlier rows — strictly-linear chain enforced client-side. |
| List | `BoundaryHierarchyList.tsx` | Levels column (`County → SubCounty → Ward` inline) + search filter. |
| Show | `BoundaryHierarchyShow.tsx` | Inactive levels render struck-through. Chain-integrity warning. Audit section. |
| Data provider | `packages/data-provider/src/providers/dataProvider.ts` | `boundaryHierarchyGetList` aggregates sub-tenants at state scope. `create` gains a `boundary-hierarchy` branch. |
| Client fix | `packages/data-provider/src/client/DigitApiClient.ts` | `boundaryHierarchyCreate` unwraps the single-element array the server returns under `BoundaryHierarchy` (was typed as singleton, would have passed a raw array to `normalizeRecord`). |
| App | `src/App.tsx` | Registers `create={BoundaryHierarchyCreate}` on the resource. |

## API shape validation

**Create** — `POST /boundary-service/boundary-hierarchy-definition/_create`:
```json
{
  \"BoundaryHierarchy\": {
    \"tenantId\": \"ke\",
    \"hierarchyType\": \"PW_DELETEME_PROBE\",
    \"boundaryHierarchy\": [
      {\"boundaryType\":\"County\",\"parentBoundaryType\":null,\"active\":true},
      {\"boundaryType\":\"SubCounty\",\"parentBoundaryType\":\"County\",\"active\":true}
    ]
  }
}
```
Returned `{BoundaryHierarchy: [{id: ..., tenantId, hierarchyType, boundaryHierarchy}]}` — array, not singleton. Client now unwraps both shapes.

**Read back** — `POST /_search` with `{hierarchyType:\"PW_DELETEME_PROBE\"}` → `{BoundaryHierarchy:[{...}]}` (1 record) at `ke`.

**Update** / **Delete** — both `400 NoResourceFoundException`. Confirmed no fix path; Create is as good as it gets.

## Leftover probe records

Two probe hierarchies created on `ke` during validation: `PW_DELETEME_PROBE`, `PW_DELETEME_PROBE2`. Since the server has no delete path, they linger. The `_DELETEME` prefix flags them for manual DB cleanup if needed. They do not conflict with real tenant work (different hierarchyType than `ADMIN`).

## Testing plan

- [ ] Navigate `/manage/boundary-hierarchies`. List shows ADMIN hierarchies from `ke` + every city sub-tenant with a hierarchy seeded. Levels column renders inline.
- [ ] Click Create. Enter `TEST_HIERARCHY`. Add 3 rows: `Level1` (root), `Level2` (parent=Level1), `Level3` (parent=Level2). Save. Record appears in list.
- [ ] Remove the middle row from the form — parent references in later rows coerce to null automatically.
- [ ] Open the seeded `ADMIN` hierarchy's Show page. Audit section shows createdBy + times. If any level is inactive, it renders struck-through with an \"(inactive)\" tag.
- [ ] Try navigating to `/manage/boundary-hierarchies/<id>/edit` — should 404 since no Edit is registered.

## Clash analysis

- No overlap with the Playwright scaffold PR (`ChakshuGautam/digit-integration-tests#1`).
- Builds atop merged PRs #5-#9 (dept/desig + complaint surfaces).
- The sub-tenant aggregation pattern mirrors the one introduced in `boundaryGetList` (commit 155dc22) — intentional parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)