### PR TITLE
fix: list-context crash on dept/desig + PGR sortBy enum mismatch

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -343,12 +343,25 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
             : undefined;
         const q = typeof filter.q === 'string' ? filter.q.trim() : undefined;
 
+        // PGR's RequestSearchCriteria.SortBy is a restricted Java enum
+        // (locality | applicationStatus | serviceRequestId). Anything else
+        // fails Jackson deserialization with a 500. Map our column sources
+        // onto the enum and drop sortBy otherwise — the server's default
+        // ORDER BY ser_createdtime kicks in, which is what the "Created"
+        // column wants anyway.
+        const pgrSortByMap: Record<string, string> = {
+          serviceRequestId: 'serviceRequestId',
+          applicationStatus: 'applicationStatus',
+          'address.locality.code': 'locality',
+          locality: 'locality',
+        };
+        const pgrSortBy = pgrSortByMap[field];
+
         const searchOpts = {
           status: typeof status === 'string' ? status : undefined,
           fromDate,
           toDate,
-          sortBy: field,
-          sortOrder: order,
+          ...(pgrSortBy ? { sortBy: pgrSortBy, sortOrder: order } : { sortOrder: order }),
           limit: perPage,
           offset: (page - 1) * perPage,
         };

--- a/src/resources/departments/DepartmentList.tsx
+++ b/src/resources/departments/DepartmentList.tsx
@@ -47,28 +47,28 @@ const exportColumns = [
 
 export function DepartmentList() {
   return (
-    <div className="space-y-3">
-      <div className="flex justify-end gap-2">
-        <BulkExportButton
-          filename="departments"
-          sheetName="Department"
-          columns={exportColumns}
-        />
-        <Button asChild variant="outline" size="sm" className="gap-1.5">
-          <Link to="/manage/departments/bulk">
-            <Upload className="w-4 h-4" />
-            Bulk import
-          </Link>
-        </Button>
-      </div>
-      <DigitList
-        title="app.resources.departments"
-        hasCreate
-        sort={{ field: 'code', order: 'ASC' }}
-        filters={filters}
-      >
-        <DigitDatagrid columns={columns} rowClick="show" />
-      </DigitList>
-    </div>
+    <DigitList
+      title="app.resources.departments"
+      hasCreate
+      sort={{ field: 'code', order: 'ASC' }}
+      filters={filters}
+      actions={
+        <>
+          <BulkExportButton
+            filename="departments"
+            sheetName="Department"
+            columns={exportColumns}
+          />
+          <Button asChild variant="outline" size="sm" className="gap-1.5">
+            <Link to="/manage/departments/bulk">
+              <Upload className="w-4 h-4" />
+              Bulk import
+            </Link>
+          </Button>
+        </>
+      }
+    >
+      <DigitDatagrid columns={columns} rowClick="show" />
+    </DigitList>
   );
 }

--- a/src/resources/designations/DesignationList.tsx
+++ b/src/resources/designations/DesignationList.tsx
@@ -70,28 +70,28 @@ const exportColumns = [
 
 export function DesignationList() {
   return (
-    <div className="space-y-3">
-      <div className="flex justify-end gap-2">
-        <BulkExportButton
-          filename="designations"
-          sheetName="Designation"
-          columns={exportColumns}
-        />
-        <Button asChild variant="outline" size="sm" className="gap-1.5">
-          <Link to="/manage/designations/bulk">
-            <Upload className="w-4 h-4" />
-            Bulk import
-          </Link>
-        </Button>
-      </div>
-      <DigitList
-        title="app.resources.designations"
-        hasCreate
-        sort={{ field: 'code', order: 'ASC' }}
-        filters={filters}
-      >
-        <DigitDatagrid columns={columns} rowClick="show" />
-      </DigitList>
-    </div>
+    <DigitList
+      title="app.resources.designations"
+      hasCreate
+      sort={{ field: 'code', order: 'ASC' }}
+      filters={filters}
+      actions={
+        <>
+          <BulkExportButton
+            filename="designations"
+            sheetName="Designation"
+            columns={exportColumns}
+          />
+          <Button asChild variant="outline" size="sm" className="gap-1.5">
+            <Link to="/manage/designations/bulk">
+              <Upload className="w-4 h-4" />
+              Bulk import
+            </Link>
+          </Button>
+        </>
+      }
+    >
+      <DigitDatagrid columns={columns} rowClick="show" />
+    </DigitList>
   );
 }


### PR DESCRIPTION
## Summary

Three live bugs on https://naipepea.digit.org/configurator/ :

1. **/manage/departments** and **/manage/designations** threw `useListContext must be used inside a ListContextProvider` and refused to render. Cause: `BulkExportButton` (which calls `useListContext`) was mounted *above* `<DigitList>`, i.e. outside the `ListContextProvider`. Fix: pass the bulk buttons via `DigitList`'s `actions` prop so they mount inside the provider.
2. **/manage/complaints** threw `Failed to convert property value ... RequestSearchCriteria$SortBy for value [auditDetails.createdTime]`. Cause: the column's `source` path was forwarded straight to PGR's `_search` as `sortBy`, but the server's `SortBy` Java enum only accepts `locality | applicationStatus | serviceRequestId`. Fix: map recognised column sources onto the enum in `dataProvider.ts` and drop `sortBy` otherwise — the server's default `ORDER BY ser_createdtime` covers the Created-column intent.

No API or data-shape changes. EmployeeList wasn't affected (its outside-the-list button doesn't touch list context).

Verified by building the branch on naipepea and rendering the three pages.

## Test plan

- [ ] `/manage/departments` — page loads, bulk export + bulk import buttons visible in the header actions row
- [ ] `/manage/designations` — same as above
- [ ] `/manage/complaints` — list loads sorted by created time DESC (server default) with no 500
- [ ] Complaint column headers `serviceRequestId` and `applicationStatus` still trigger a server-side sort
- [ ] Clicking the "Created" column header is a no-op or client-only (no 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sorting validation to restrict data filtering to valid field values only.

* **Refactor**
  * Reorganized bulk export and import action controls in department and designation management lists for improved UI structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->