### PR TITLE
boundary-hierarchies: tenant selector on Create

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -567,6 +567,10 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         const data = params.data as Record<string, unknown>;
         const hierarchyType = String(data.hierarchyType ?? '').trim();
         if (!hierarchyType) throw new Error('hierarchyType is required');
+        const targetTenantId =
+          typeof data.tenantId === 'string' && data.tenantId.trim()
+            ? data.tenantId.trim()
+            : tenantId;
         const levelsInput = Array.isArray(data.boundaryHierarchy) ? data.boundaryHierarchy : [];
         const levels = levelsInput
           .map((lvl) => lvl as Record<string, unknown>)
@@ -580,7 +584,7 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
           }));
         if (levels.length === 0) throw new Error('At least one hierarchy level is required');
         const created = await client.boundaryHierarchyCreate(
-          tenantId,
+          targetTenantId,
           hierarchyType,
           levels,
         );

--- a/src/resources/boundary-hierarchies/BoundaryHierarchyCreate.tsx
+++ b/src/resources/boundary-hierarchies/BoundaryHierarchyCreate.tsx
@@ -1,18 +1,32 @@
-import { DigitCreate, DigitFormInput, v } from '@/admin';
+import { DigitCreate, DigitFormInput, DigitFormSelect, v } from '@/admin';
 import { FieldSection } from '@/admin/fields';
 import { HierarchyLevelEditor } from './HierarchyLevelEditor';
+import { useApp } from '@/App';
 
-/** Create a boundary hierarchy on the session tenant. Immutable after
+/** Create a boundary hierarchy on a chosen tenant. Immutable after
  *  creation — the `boundary-hierarchy-definition` service exposes only
  *  `_search` and `_create`; `_update` / `_delete` both return 400. Surface
  *  a single-shot Create only; do not register Edit or Delete. */
 export function BoundaryHierarchyCreate() {
+  const { state } = useApp();
   return (
     <DigitCreate
       title="Create Boundary Hierarchy"
-      record={{ boundaryHierarchy: [{ boundaryType: '', parentBoundaryType: null }] }}
+      record={{
+        tenantId: state.tenant,
+        boundaryHierarchy: [{ boundaryType: '', parentBoundaryType: null }],
+      }}
     >
       <FieldSection title="Details">
+        <DigitFormSelect
+          source="tenantId"
+          label="Tenant"
+          reference="tenants"
+          optionValue="code"
+          optionText="code"
+          validate={v.codeRequired}
+          placeholder="Select tenant"
+        />
         <DigitFormInput
           source="hierarchyType"
           label="Hierarchy Type"


### PR DESCRIPTION
## Summary

The boundary-hierarchies list shows `tenantId` as a column, so a root-tenant admin (e.g. logged in as `ke`) can see hierarchies defined at sub-tenants like `ke.nairobi`. But the Create form had no tenant field — it silently created the hierarchy on the session tenant, so there was no UI path to create a hierarchy targeted at a sub-tenant from a root login.

- Add a `DigitFormSelect` backed by the `tenants` resource (MDMS `tenant.tenants`) to `BoundaryHierarchyCreate`.
- Default the form's `tenantId` to `state.tenant` (the session tenant) so sub-tenant logins keep their existing behaviour.
- In the dataProvider, prefer `data.tenantId` and fall back to the session `tenantId` — no regression for existing callers.

## Test plan

- [ ] Logged in as root `ke`: `/manage/boundary-hierarchies/create` shows a Tenant dropdown listing `ke`, `ke.nairobi`, etc. Pick `ke.nairobi`, create `TEST_HIERARCHY` with a root level, confirm the new row appears with `tenantId=ke.nairobi` in the list.
- [ ] Logged in as root `ke`: default selection is `ke`, omitting the change creates at root (pre-PR behaviour).
- [ ] Existing hierarchies listed — both root and sub-tenant rows still render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)