### PR TITLE
onboarding: separate target tenant from session tenant (closes #13)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,14 @@ interface AppState {
   isAuthenticated: boolean;
   user: { name: string; email: string; roles: string[]; id?: number; uuid?: string; mobileNumber?: string } | null;
   environment: string;
+  /** Session tenant — the tenant the authenticated user lives under. Stays
+   *  put for the whole walk; used for auth, schema lookups, and any operation
+   *  that has to happen at the state-root tenant. */
   tenant: string;
+  /** Target tenant — the tenant that phases 2–4 write to and read from.
+   *  Set by Phase 1 after a successful tenant create; defaults to the session
+   *  tenant so anything that skips Phase 1 keeps today's behavior. */
+  targetTenant: string;
   mode: AppMode;
   currentPhase: number;
   completedPhases: number[];
@@ -60,6 +67,9 @@ interface AppContextType {
   login: (user: AppState['user'], env: string, tenant: string, mode: AppMode) => void;
   logout: () => void;
   setMode: (mode: AppMode) => void;
+  /** Point subsequent onboarding writes/reads at a child tenant. Called by
+   *  Phase 1 after `tenant.tenants` create succeeds. */
+  setTargetTenant: (code: string) => void;
   completePhase: (phase: number) => void;
   goToPhase: (phase: number) => void;
   addUndo: (action: string, description: string) => void;
@@ -134,7 +144,7 @@ function ManagementAdmin() {
 const AUTH_STORAGE_KEY = 'crs-auth-state';
 
 // Helper to restore apiClient from localStorage
-function restoreApiClientFromStorage(): { isAuthenticated: boolean; user: AppState['user']; environment: string; tenant: string; mode: AppMode; currentPhase: number; completedPhases: number[] } | null {
+function restoreApiClientFromStorage(): { isAuthenticated: boolean; user: AppState['user']; environment: string; tenant: string; targetTenant: string; mode: AppMode; currentPhase: number; completedPhases: number[] } | null {
   const saved = localStorage.getItem(AUTH_STORAGE_KEY);
   if (!saved) return null;
 
@@ -177,6 +187,7 @@ function restoreApiClientFromStorage(): { isAuthenticated: boolean; user: AppSta
         user: parsed.user,
         environment: restoredEnv,
         tenant: restoredTenant,
+        targetTenant: parsed.targetTenant || restoredTenant,
         mode: parsed.mode || 'onboarding',
         currentPhase: parsed.currentPhase || 1,
         completedPhases: parsed.completedPhases || [],
@@ -204,6 +215,7 @@ function App() {
       user: null,
       environment: getApiBaseUrl(),
       tenant: 'ke',
+      targetTenant: 'ke',
       mode: 'onboarding',
       currentPhase: 1,
       completedPhases: [],
@@ -246,6 +258,7 @@ function App() {
         user: state.user,
         environment: state.environment,
         tenant: state.tenant,
+        targetTenant: state.targetTenant,
         mode: state.mode,
         currentPhase: state.currentPhase,
         completedPhases: state.completedPhases,
@@ -253,10 +266,12 @@ function App() {
       };
       localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(authData));
     }
-  }, [state.isAuthenticated, state.user, state.environment, state.tenant, state.mode, state.currentPhase, state.completedPhases]);
+  }, [state.isAuthenticated, state.user, state.environment, state.tenant, state.targetTenant, state.mode, state.currentPhase, state.completedPhases]);
 
   const login = (user: AppState['user'], env: string, tenant: string, mode: AppMode) => {
-    setState(s => ({ ...s, isAuthenticated: true, user, environment: env, tenant, mode }));
+    // Fresh login resets targetTenant to the session tenant. Phase 1 will
+    // point it at a child tenant once a create succeeds.
+    setState(s => ({ ...s, isAuthenticated: true, user, environment: env, tenant, targetTenant: tenant, mode }));
 
     // Configure digitClient with the same auth as apiClient
     const { token } = apiClient.getAuth();
@@ -291,6 +306,11 @@ function App() {
     trackEvent('mode_switch', { mode });
   };
 
+  const setTargetTenant = (code: string) => {
+    setState(s => ({ ...s, targetTenant: code }));
+    trackEvent('target_tenant_set', { targetTenant: code });
+  };
+
   const logout = () => {
     trackEvent('logout', { tenant: state.tenant });
     clearUser();
@@ -301,7 +321,7 @@ function App() {
     apiClient.logout();
     digitClient.clearAuth();
     resetProviders();
-    setState(s => ({ ...s, isAuthenticated: false, user: null, mode: 'onboarding', currentPhase: 1, completedPhases: [] }));
+    setState(s => ({ ...s, isAuthenticated: false, user: null, mode: 'onboarding', currentPhase: 1, completedPhases: [], targetTenant: s.tenant }));
   };
 
   const completePhase = (phase: number) => {
@@ -383,6 +403,7 @@ function App() {
     login,
     logout,
     setMode,
+    setTargetTenant,
     completePhase,
     goToPhase,
     addUndo,

--- a/src/pages/CompletePage.tsx
+++ b/src/pages/CompletePage.tsx
@@ -30,6 +30,7 @@ const INITIAL_SUMMARY: TenantSummary = {
 
 export default function CompletePage() {
   const { state, logout } = useApp();
+  const targetTenant = state.targetTenant || state.tenant;
   const navigate = useNavigate();
   const [summary, setSummary] = useState<TenantSummary>(INITIAL_SUMMARY);
 
@@ -40,11 +41,11 @@ export default function CompletePage() {
         // Fetch in parallel; swallow per-resource errors so one broken
         // endpoint doesn't zero out the whole summary.
         const [departments, designations, complaintTypes, boundaries, employees] = await Promise.all([
-          mdmsService.getDepartments(state.tenant).catch(() => [] as unknown[]),
-          mdmsService.getDesignations(state.tenant).catch(() => [] as unknown[]),
-          mdmsService.getComplaintTypes(state.tenant).catch(() => [] as unknown[]),
-          boundaryService.searchBoundaries(state.tenant).catch(() => [] as unknown[]),
-          hrmsService.searchEmployees(state.tenant).catch(() => [] as unknown[]),
+          mdmsService.getDepartments(targetTenant).catch(() => [] as unknown[]),
+          mdmsService.getDesignations(targetTenant).catch(() => [] as unknown[]),
+          mdmsService.getComplaintTypes(targetTenant).catch(() => [] as unknown[]),
+          boundaryService.searchBoundaries(targetTenant).catch(() => [] as unknown[]),
+          hrmsService.searchEmployees(targetTenant).catch(() => [] as unknown[]),
         ]);
         if (cancelled) return;
         setSummary({
@@ -68,7 +69,7 @@ export default function CompletePage() {
     return () => {
       cancelled = true;
     };
-  }, [state.tenant]);
+  }, [targetTenant]);
 
   const handleLogout = () => {
     logout();
@@ -119,7 +120,7 @@ export default function CompletePage() {
         <div className="bg-primary/5 border border-primary/20 rounded p-4 sm:p-6 mb-6 sm:mb-8 text-left">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 gap-2">
             <div>
-              <p className="font-condensed font-semibold text-foreground text-sm sm:text-base">Tenant: <span className="text-primary">{state.tenant.toUpperCase()}</span></p>
+              <p className="font-condensed font-semibold text-foreground text-sm sm:text-base">Tenant: <span className="text-primary">{targetTenant.toUpperCase()}</span></p>
               <p className="text-xs sm:text-sm text-muted-foreground truncate">Environment: {state.environment.replace('https://', '')}</p>
             </div>
             <a
@@ -144,7 +145,7 @@ export default function CompletePage() {
                 <TableBody>
                   <TableRow>
                     <TableCell className="text-xs sm:text-sm">Phase 1: Tenant & Branding</TableCell>
-                    <TableCell className="text-primary text-xs sm:text-sm font-medium">{state.tenant}</TableCell>
+                    <TableCell className="text-primary text-xs sm:text-sm font-medium">{targetTenant}</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="text-xs sm:text-sm">Phase 2: Boundary Setup</TableCell>
@@ -170,7 +171,7 @@ export default function CompletePage() {
                 <p className="text-xs text-destructive mt-2">Failed to load counts: {summary.error}</p>
               )}
               <p className="text-[11px] text-muted-foreground mt-2">
-                Counts reflect the current total at tenant <code>{state.tenant}</code> — including any data present from earlier setup sessions. To see only what this walk created, browse the Management UI and filter by code prefix.
+                Counts reflect the current total at tenant <code>{targetTenant}</code> — including any data present from earlier setup sessions. To see only what this walk created, browse the Management UI and filter by code prefix.
               </p>
             </div>
           </div>

--- a/src/pages/Phase1Page.tsx
+++ b/src/pages/Phase1Page.tsx
@@ -69,7 +69,7 @@ const BRANDING_FIELDS: ReadonlyArray<{
 ];
 
 export default function Phase1Page() {
-  const { completePhase, addUndo, state } = useApp();
+  const { completePhase, addUndo, state, setTargetTenant } = useApp();
   const navigate = useNavigate();
   const rootTenant = state.tenant;
   const [step, setStep] = useState<Step>('landing');
@@ -149,6 +149,9 @@ export default function Phase1Page() {
       );
 
       setCreatedTenant(tenant);
+      // Retarget subsequent phases at the freshly-created child tenant so
+      // Phases 2–4 write to (and read from) it instead of the session root.
+      setTargetTenant(tenant.code);
       addUndo('create_tenant', `Created tenant: ${tenant.code}`);
       setStep('branding');
     } catch (err) {

--- a/src/pages/Phase2Page.tsx
+++ b/src/pages/Phase2Page.tsx
@@ -35,6 +35,9 @@ type Step = 'landing' | 'create-hierarchy' | 'select-hierarchy' | 'template' | '
 export default function Phase2Page() {
   const { completePhase, addUndo, state } = useApp();
   const navigate = useNavigate();
+  // Phase 1 points targetTenant at the newly-created tenant. Fall back to
+  // the session tenant for sessions that skip Phase 1 (e.g. URL-direct).
+  const targetTenant = state.targetTenant || state.tenant;
 
   const [step, setStep] = useState<Step>('landing');
   const [loading, setLoading] = useState(false);
@@ -61,12 +64,12 @@ export default function Phase2Page() {
   // Fetch existing hierarchies on mount
   useEffect(() => {
     fetchHierarchies();
-  }, [state.tenant]);
+  }, [targetTenant]);
 
   const fetchHierarchies = async () => {
     setLoadingHierarchies(true);
     try {
-      const hierarchies = await boundaryService.getHierarchies(state.tenant);
+      const hierarchies = await boundaryService.getHierarchies(targetTenant);
       setExistingHierarchies(hierarchies);
       if (hierarchies.length > 0) {
         setSelectedHierarchy(hierarchies[0]);
@@ -96,7 +99,7 @@ export default function Phase2Page() {
 
     try {
       const newHierarchy = await boundaryService.createHierarchyFromLevels(
-        state.tenant,
+        targetTenant,
         hierarchyType,
         validLevels
       );
@@ -209,7 +212,7 @@ export default function Phase2Page() {
     try {
       // Convert Excel rows to Boundary objects
       const boundariesToCreate: Boundary[] = validBoundaries.map(row => ({
-        tenantId: state.tenant,
+        tenantId: targetTenant,
         code: row.code,
         name: row.name,
         boundaryType: row.boundaryType,
@@ -241,7 +244,7 @@ export default function Phase2Page() {
       }));
 
       await localizationService.uploadBoundaryLocalizations(
-        state.tenant,
+        targetTenant,
         boundaryData,
         selectedHierarchy.hierarchyType,
         'en_IN'
@@ -370,7 +373,7 @@ export default function Phase2Page() {
       {step === 'create-hierarchy' && (
         <DigitCard>
           <SubHeader>Create Boundary Hierarchy</SubHeader>
-          <p className="text-xs sm:text-sm text-muted-foreground mb-4 sm:mb-6">Define the boundary hierarchy for tenant: <span className="text-primary font-medium">{state.tenant.toUpperCase()}</span></p>
+          <p className="text-xs sm:text-sm text-muted-foreground mb-4 sm:mb-6">Define the boundary hierarchy for tenant: <span className="text-primary font-medium">{targetTenant.toUpperCase()}</span></p>
 
           <div className="space-y-6">
             <LabelFieldPair>
@@ -448,7 +451,7 @@ export default function Phase2Page() {
           <div className="flex items-center justify-between mb-4 sm:mb-6">
             <div>
               <SubHeader>Select Existing Hierarchy</SubHeader>
-              <p className="text-xs sm:text-sm text-muted-foreground">Available hierarchies for tenant: <span className="text-primary font-medium">{state.tenant.toUpperCase()}</span></p>
+              <p className="text-xs sm:text-sm text-muted-foreground">Available hierarchies for tenant: <span className="text-primary font-medium">{targetTenant.toUpperCase()}</span></p>
             </div>
             <Button
               variant="ghost"
@@ -672,7 +675,7 @@ export default function Phase2Page() {
           <Banner
             successful={true}
             message="Boundaries Created Successfully!"
-            info={`Hierarchy: ${selectedHierarchy.hierarchyType} • Tenant: ${state.tenant.toUpperCase()}`}
+            info={`Hierarchy: ${selectedHierarchy.hierarchyType} • Tenant: ${targetTenant.toUpperCase()}`}
           />
 
           <div className="mt-6 p-4 bg-muted rounded overflow-x-auto">

--- a/src/pages/Phase3Page.tsx
+++ b/src/pages/Phase3Page.tsx
@@ -41,6 +41,7 @@ type Step = 'landing' | 'upload' | 'preview' | 'creating-depts' | 'creating-comp
 
 export default function Phase3Page() {
   const { completePhase, addUndo, state } = useApp();
+  const targetTenant = state.targetTenant || state.tenant;
   const navigate = useNavigate();
 
   const [step, setStep] = useState<Step>('landing');
@@ -124,7 +125,7 @@ export default function Phase3Page() {
       if (departments.length > 0) {
         setProgressMessage('Creating departments...');
         const deptResults = await mdmsService.createDepartments(
-          state.tenant,
+          targetTenant,
           departments.map(d => ({
             code: d.code,
             name: d.name,
@@ -136,7 +137,7 @@ export default function Phase3Page() {
 
         // Create localizations for departments
         await localizationService.uploadDepartmentLocalizations(
-          state.tenant,
+          targetTenant,
           departments.map(d => ({ code: d.code, name: d.name })),
           'en_IN'
         );
@@ -148,7 +149,7 @@ export default function Phase3Page() {
       if (designations.length > 0) {
         setProgressMessage('Creating designations...');
         const desigResults = await mdmsService.createDesignations(
-          state.tenant,
+          targetTenant,
           designations.map(d => ({
             code: d.code,
             name: d.name,
@@ -162,7 +163,7 @@ export default function Phase3Page() {
 
         // Create localizations for designations
         await localizationService.uploadDesignationLocalizations(
-          state.tenant,
+          targetTenant,
           designations.map(d => ({ code: d.code, name: d.name })),
           'en_IN'
         );
@@ -180,7 +181,7 @@ export default function Phase3Page() {
       if (complaintTypes.length > 0) {
         setProgressMessage('Creating complaint types...');
         const complaintResults = await mdmsService.createComplaintTypes(
-          state.tenant,
+          targetTenant,
           complaintTypes.map(ct => ({
             serviceCode: ct.serviceCode,
             name: ct.name,
@@ -195,7 +196,7 @@ export default function Phase3Page() {
 
         // Create localizations for complaint types
         await localizationService.uploadComplaintTypeLocalizations(
-          state.tenant,
+          targetTenant,
           complaintTypes.map(ct => ({
             serviceCode: ct.serviceCode,
             name: ct.name,
@@ -615,7 +616,7 @@ export default function Phase3Page() {
           <Banner
             successful={true}
             message="Phase 3 Complete!"
-            info={`Common masters configured for tenant: ${state.tenant.toUpperCase()}`}
+            info={`Common masters configured for tenant: ${targetTenant.toUpperCase()}`}
           />
 
           <div className="mt-6 p-4 bg-muted rounded">

--- a/src/pages/Phase4Page.tsx
+++ b/src/pages/Phase4Page.tsx
@@ -53,6 +53,7 @@ interface ParsedEmployee extends EmployeeExcelRow {
 
 export default function Phase4Page() {
   const { completePhase, addUndo, state } = useApp();
+  const targetTenant = state.targetTenant || state.tenant;
   const navigate = useNavigate();
 
   const [step, setStep] = useState<Step>('landing');
@@ -82,17 +83,17 @@ export default function Phase4Page() {
   // Fetch reference data on mount
   useEffect(() => {
     fetchReferenceData();
-  }, [state.tenant]);
+  }, [targetTenant]);
 
   const fetchReferenceData = async () => {
     setLoadingRefs(true);
     try {
       const [depts, desigs, bounds, fetchedRoles, fetchedMobileRules] = await Promise.all([
-        mdmsService.getDepartments(state.tenant),
-        mdmsService.getDesignations(state.tenant),
-        boundaryService.searchBoundaries(state.tenant),
-        mdmsService.getRoles(state.tenant).catch(() => [] as typeof roles),
-        mdmsService.getMobileValidation(state.tenant).catch(() => null),
+        mdmsService.getDepartments(targetTenant),
+        mdmsService.getDesignations(targetTenant),
+        boundaryService.searchBoundaries(targetTenant),
+        mdmsService.getRoles(targetTenant).catch(() => [] as typeof roles),
+        mdmsService.getMobileValidation(targetTenant).catch(() => null),
       ]);
       setDepartments(depts);
       setDesignations(desigs);
@@ -253,7 +254,7 @@ export default function Phase4Page() {
 
           // Build employee object
           const employee = hrmsService.buildEmployee({
-            tenantId: state.tenant,
+            tenantId: targetTenant,
             code: emp.employeeCode || hrmsService.generateEmployeeCode('EMP', i + 1),
             name: emp.name,
             userName: emp.userName || hrmsService.generateUsername(emp.name),
@@ -327,7 +328,7 @@ export default function Phase4Page() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `employee_credentials_${state.tenant}.csv`;
+    a.download = `employee_credentials_${targetTenant}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -439,7 +440,7 @@ export default function Phase4Page() {
               <strong className="text-sm font-condensed">Template Generated!</strong>
             </div>
             <p className="text-xs sm:text-sm mb-2 text-foreground">
-              Employee_Master_Dynamic_{state.tenant.toUpperCase()}.xlsx
+              Employee_Master_Dynamic_{targetTenant.toUpperCase()}.xlsx
             </p>
 
             <div className="grid grid-cols-2 gap-2 sm:gap-4 text-xs sm:text-sm mb-3 sm:mb-4">
@@ -732,8 +733,8 @@ export default function Phase4Page() {
             }
             info={
               failedCount > 0
-                ? `Tenant: ${state.tenant.toUpperCase()} • Check the failure list below and retry the failed rows.`
-                : `Tenant: ${state.tenant.toUpperCase()}`
+                ? `Tenant: ${targetTenant.toUpperCase()} • Check the failure list below and retry the failed rows.`
+                : `Tenant: ${targetTenant.toUpperCase()}`
             }
           />
 


### PR DESCRIPTION
Closes #13.

## What

Introduces a `targetTenant` in AppContext that's distinct from the session `tenant`:

- Session `tenant` = the tenant the authenticated user lives under (auth context). Stays put.
- `targetTenant` = the tenant Phases 2–4 write to and read from. Set by Phase 1 after tenant create; defaults to session tenant as fallback.

## Why

Before this PR, Phases 2–4 used `state.tenant` — the session tenant — for every MDMS / boundary / HRMS operation. Phase 1 created a child tenant but never updated any app-level pointer. The upshot: users onboarded "a new city" and all the boundaries / masters / employees landed at the **parent** tenant, not the one just created. Phase 4 even showed 30+ seeded designations from the parent as if they were the new tenant's data. Verified with MDMS v2: searches are strict on `tenantId`, no parent inheritance — so the only explanation was that `state.tenant` pointed at the wrong place.

## Files touched

- `src/App.tsx`: add `targetTenant` to `AppState` / `AppContextType`, `setTargetTenant` setter, persist in localStorage, reset on login/logout.
- `src/pages/Phase1Page.tsx`: call `setTargetTenant(tenant.code)` right after tenant create succeeds.
- `src/pages/Phase{2,3,4}Page.tsx`, `src/pages/CompletePage.tsx`: derive `const targetTenant = state.targetTenant || state.tenant;` at the top; replace every `state.tenant` used as a `tenantId` payload / reference-data fetch with `targetTenant`. Display strings updated too.

## Scope

+70 / −40 across 6 files. No schema or backend changes. Additive to context shape.

## Test plan

- [x] `/phase/1`: upload `01-tenant-master.xlsx` (creates `ke.testzone`). After create, localStorage `crs-auth-state` includes `targetTenant: "ke.testzone"`.
- [ ] `/phase/2`: boundaries get written at `ke.testzone` — verify via `GET /boundary-service/boundary-relationships/_search?tenantId=ke.testzone`.
- [ ] `/phase/3`: departments/designations/complaint-types created at `ke.testzone` — verify via MDMS search at that tenant.
- [ ] `/phase/4`: reference-data summary shows the records just created (not 30+ parent-tenant records). Employees created with `tenantId=ke.testzone`.
- [ ] `/complete`: counts reflect `ke.testzone`, not `ke`.
- [ ] Fallback: hit `/phase/3` directly without running Phase 1 — `targetTenant` falls back to session tenant, behavior unchanged from today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)