### PR TITLE
fix(manage): users filter + deactivation-reason merge + tenant district em-dash

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -198,8 +198,16 @@ async function localizationGetList(client: DigitApiClient, config: ResourceConfi
 
 async function userGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string, filter?: Record<string, unknown>): Promise<RaRecord[]> {
   const opts: { userName?: string; mobileNumber?: string; uuid?: string[]; roleCodes?: string[]; userType?: string; limit: number } = { limit: 100 };
-  if (filter?.userName) opts.userName = String(filter.userName);
-  if (filter?.mobileNumber) opts.mobileNumber = String(filter.mobileNumber);
+  // `q` is a single-input "quick search". Digits (optionally +/0-prefixed, with spaces or
+  // dashes) route to mobileNumber; anything else routes to userName. Explicit field
+  // filters below can still override if both are present.
+  const q = typeof filter?.q === 'string' ? filter.q.trim() : '';
+  if (q) {
+    if (/^[+\d][\d\s-]*$/.test(q)) opts.mobileNumber = q.replace(/[\s-]/g, '');
+    else opts.userName = q;
+  }
+  if (!opts.userName && filter?.userName) opts.userName = String(filter.userName);
+  if (!opts.mobileNumber && filter?.mobileNumber) opts.mobileNumber = String(filter.mobileNumber);
   if (filter?.userType) opts.userType = String(filter.userType);
   if (filter?.roleCodes) opts.roleCodes = filter.roleCodes as string[];
   if (filter?.uuid) opts.uuid = Array.isArray(filter.uuid) ? filter.uuid as string[] : [String(filter.uuid)];

--- a/src/resources/employees/EmployeeEdit.tsx
+++ b/src/resources/employees/EmployeeEdit.tsx
@@ -181,19 +181,23 @@ export function EmployeeEdit() {
     sort: { field: 'code', order: 'ASC' },
   });
   const reasonChoices = useMemo(() => {
-    const base = (reasonsList ?? []).map((r) => {
+    // The hardcoded list is a floor, not a fallback — a thinly-seeded MDMS
+    // (e.g. Nairobi ships with only ORDERBYCOMMISSIONER + OTHERS) should not
+    // hide standard HR exits. Merge MDMS with defaults and dedup by code;
+    // MDMS entries win on collision so operators can still rename labels
+    // centrally.
+    const DEFAULTS = [
+      { value: 'OTHERS', label: 'Others' },
+      { value: 'RETIRED', label: 'Retired' },
+      { value: 'TERMINATED', label: 'Terminated' },
+      { value: 'RESIGNED', label: 'Resigned' },
+    ];
+    const mdmsChoices = (reasonsList ?? []).map((r) => {
       const code = String((r as Record<string, unknown>).code ?? r.id);
       return { value: code, label: code };
     });
-    if (base.length === 0) {
-      return [
-        { value: 'OTHERS', label: 'Others' },
-        { value: 'RETIRED', label: 'Retired' },
-        { value: 'TERMINATED', label: 'Terminated' },
-        { value: 'RESIGNED', label: 'Resigned' },
-      ];
-    }
-    return base;
+    const seen = new Set(mdmsChoices.map((c) => c.value));
+    return [...mdmsChoices, ...DEFAULTS.filter((d) => !seen.has(d.value))];
   }, [reasonsList]);
 
   const transform = (data: Record<string, unknown>): Record<string, unknown> => {

--- a/src/resources/tenants/TenantList.tsx
+++ b/src/resources/tenants/TenantList.tsx
@@ -5,7 +5,17 @@ const columns: DigitColumn[] = [
   { source: 'code', label: 'app.fields.code' },
   { source: 'name', label: 'app.fields.name' },
   { source: 'city.name', label: 'app.fields.city' },
-  { source: 'city.districtName', label: 'app.fields.district' },
+  {
+    source: 'city.districtName',
+    label: 'app.fields.district',
+    render: (record) => {
+      const city = record.city as Record<string, unknown> | undefined;
+      const districtName = typeof city?.districtName === 'string' ? city.districtName : '';
+      return districtName
+        ? <span>{districtName}</span>
+        : <span className="text-muted-foreground" title="Missing city.districtName in tenant MDMS">—</span>;
+    },
+  },
 ];
 
 export function TenantList() {

--- a/src/resources/users/UserList.tsx
+++ b/src/resources/users/UserList.tsx
@@ -1,7 +1,22 @@
-import { DigitList, DigitDatagrid } from '@/admin';
+import { DigitList, DigitDatagrid, SearchFilterInput, SelectFilterInput } from '@/admin';
 import type { DigitColumn } from '@/admin';
 import { StatusChip } from '@/admin/fields';
 import { Badge } from '@/components/ui/badge';
+
+const filters = [
+  <SearchFilterInput key="q" source="q" alwaysOn />,
+  <SelectFilterInput
+    key="userType"
+    source="userType"
+    label="Type"
+    choices={[
+      { id: 'CITIZEN', name: 'Citizen' },
+      { id: 'EMPLOYEE', name: 'Employee' },
+      { id: 'SYSTEM', name: 'System' },
+    ]}
+    alwaysOn
+  />,
+];
 
 const columns: DigitColumn[] = [
   { source: 'userName', label: 'app.fields.username' },
@@ -37,7 +52,7 @@ const columns: DigitColumn[] = [
 
 export function UserList() {
   return (
-    <DigitList title="app.resources.users" hasCreate sort={{ field: 'userName', order: 'ASC' }}>
+    <DigitList title="app.resources.users" hasCreate sort={{ field: 'userName', order: 'ASC' }} filters={filters}>
       <DigitDatagrid columns={columns} rowClick="show" />
     </DigitList>
   );


### PR DESCRIPTION
## Summary
Three small UI fixes surfaced by the 2026-04-23 manage-surface audit.

- **`fix(users)` — closes #20**: Wire `SearchFilterInput` (with smart `q` routing) + `userType` select on `/manage/users`. Operators had to page through unfiltered citizen lists to find anyone.
- **`fix(employees)` — closes #17**: Merge MDMS `deactivation-reasons` with the hardcoded defaults instead of replacing. On `ke` the MDMS seed ships only `ORDERBYCOMMISSIONER` + `OTHERS`, which silently hid `RETIRED/TERMINATED/RESIGNED`.
- **`fix(tenants)` — refs #16**: Render a muted em-dash (with tooltip) when `city.districtName` is absent so operators notice the gap. The underlying seed fix for the `ke.nairobi` row is tracked as a data task in #16.

See also the broader audit that filed #14–#24; this PR only covers the UI-fixable subset. Items #14, #15, #18, #19, #21, #22, #23, #24 need backend / gateway / seed work outside this PR.

## Test plan
- [ ] `/manage/users` renders a search box + Type select; entering digits routes to `mobileNumber`, text routes to `userName`.
- [ ] `/manage/employees/<id>/edit` → set Status = INACTIVE → dropdown shows `ORDERBYCOMMISSIONER`, `OTHERS`, `RETIRED`, `TERMINATED`, `RESIGNED` (MDMS two + the three defaults).
- [ ] `/manage/tenants` — the `ke.nairobi` row renders `—` (not blank) in the District column; hover shows the "Missing city.districtName" tooltip.
- [ ] Playwright specs on `feat/manage-e2e` in `ChakshuGautam/digit-integration-tests` pin this behavior (`users.spec.ts` search + filter tests; `employees.spec.ts` deactivation test; `tenants.spec.ts` district-quirk assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)