### PR TITLE
login + onboarding: stop autofilling creds, wire branding preview modal

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -16,9 +16,9 @@ export default function LoginPage() {
   const navigate = useNavigate();
 
   const [formData, setFormData] = useState({
-    username: 'ADMIN',
-    password: 'eGov@123',
-    tenantCode: 'ke',
+    username: '',
+    password: '',
+    tenantCode: '',
   });
   const [mode, setMode] = useState<AppMode>('onboarding');
   const [showPassword, setShowPassword] = useState(false);
@@ -106,7 +106,7 @@ export default function LoginPage() {
           <DigitCardHeader>Sign In</DigitCardHeader>
           <DigitCardSubHeader>Enter your credentials to continue</DigitCardSubHeader>
 
-          <form onSubmit={handleSubmit} className="space-y-6 mt-6">
+          <form onSubmit={handleSubmit} className="space-y-6 mt-6" autoComplete="off">
             {/* Mode Toggle */}
             <div className="space-y-2">
               <label className="text-sm font-medium text-foreground">Mode</label>
@@ -164,6 +164,7 @@ export default function LoginPage() {
                   onChange={(e) => setFormData({ ...formData, username: e.target.value })}
                   placeholder="Enter username"
                   className="border-input-border focus:border-primary focus:ring-primary"
+                  autoComplete="off"
                   required
                 />
               </Field>
@@ -181,6 +182,7 @@ export default function LoginPage() {
                     onChange={(e) => setFormData({ ...formData, password: e.target.value })}
                     className="pr-10 border-input-border focus:border-primary focus:ring-primary"
                     placeholder="Enter password"
+                    autoComplete="new-password"
                     required
                   />
                   <button
@@ -215,6 +217,7 @@ export default function LoginPage() {
                   onChange={(e) => setFormData({ ...formData, tenantCode: e.target.value })}
                   placeholder="ke"
                   className="border-input-border focus:border-primary focus:ring-primary"
+                  autoComplete="off"
                   required
                 />
                 <p className="text-xs text-muted-foreground mt-1">Root tenant for authentication</p>

--- a/src/pages/Phase1Page.tsx
+++ b/src/pages/Phase1Page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../App';
 import {
@@ -19,6 +19,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { DigitCard, DigitCardText } from '@/components/digit/DigitCard';
 import { Header, SubHeader } from '@/components/digit/Header';
 import { SubmitBar } from '@/components/digit/SubmitBar';
@@ -83,6 +84,21 @@ export default function Phase1Page() {
   // Per-row error so a bad upload surfaces inline next to the failed row,
   // not at the top of the page where users miss it.
   const [brandingErrors, setBrandingErrors] = useState<Partial<Record<keyof BrandingData, string>>>({});
+  // Object URLs of the uploaded branding files, kept local so the Preview
+  // button works without a filestore round-trip. Revoked when a row is
+  // replaced or the page unmounts.
+  const [brandingPreviews, setBrandingPreviews] = useState<Partial<Record<keyof BrandingData, string>>>({});
+  const brandingPreviewsRef = useRef(brandingPreviews);
+  brandingPreviewsRef.current = brandingPreviews;
+  const [previewingKey, setPreviewingKey] = useState<keyof BrandingData | null>(null);
+
+  useEffect(() => {
+    return () => {
+      Object.values(brandingPreviewsRef.current).forEach((url) => {
+        if (url) URL.revokeObjectURL(url);
+      });
+    };
+  }, []);
   const [validation, setValidation] = useState<ValidationResult | null>(null);
 
   // Created tenant
@@ -218,6 +234,10 @@ export default function Phase1Page() {
     try {
       const result = await apiClient.uploadFile(file, 'branding');
       setBrandingData(prev => ({ ...prev, [type]: result.fileStoreId }));
+      setBrandingPreviews(prev => {
+        if (prev[type]) URL.revokeObjectURL(prev[type]!);
+        return { ...prev, [type]: URL.createObjectURL(file) };
+      });
     } catch (err) {
       console.error('File upload error:', err);
       const msg = err instanceof Error ? err.message : 'Upload failed';
@@ -617,8 +637,13 @@ export default function Phase1Page() {
                     )}
                   </div>
                   <div className="flex gap-2 flex-shrink-0">
-                    {uploaded && (
-                      <Button variant="outline" size="sm" className="hidden sm:flex border-primary text-primary hover:bg-primary/10">
+                    {uploaded && brandingPreviews[key] && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="hidden sm:flex border-primary text-primary hover:bg-primary/10"
+                        onClick={() => setPreviewingKey(key)}
+                      >
                         <Eye className="w-4 h-4 mr-1" />
                         Preview
                       </Button>
@@ -700,6 +725,26 @@ export default function Phase1Page() {
           </div>
         </DigitCard>
       )}
+
+      {/* Branding preview modal */}
+      <Dialog open={previewingKey !== null} onOpenChange={(open) => !open && setPreviewingKey(null)}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>
+              {previewingKey && BRANDING_FIELDS.find((f) => f.key === previewingKey)?.label}
+            </DialogTitle>
+          </DialogHeader>
+          {previewingKey && brandingPreviews[previewingKey] && (
+            <div className="flex items-center justify-center bg-muted/30 rounded p-4">
+              <img
+                src={brandingPreviews[previewingKey]}
+                alt={BRANDING_FIELDS.find((f) => f.key === previewingKey)?.label}
+                className="max-h-[70vh] max-w-full object-contain"
+              />
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two easy configurator-side wins from the NCCG triage. Both are single-file-ish and don't touch any API surface.

**#412 — Login auto-fills ADMIN/eGov@123.** The form seeded `username: 'ADMIN'`, `password: 'eGov@123'`, `tenantCode: 'ke'` into state on mount, so the first submit happily taught browsers to autosave those creds. Start empty, add `autoComplete="off"` on the `<form>`, `new-password` on the password input, `off` on the other two.

**#418 — Phase 1.2 Preview button is a no-op.** Keep a local `URL.createObjectURL` per uploaded branding file and open it in a `Dialog` when Preview is clicked. No round-trip through `/filestore/v1/files/url`. Previews are only shown for rows that have a live object URL (the ref-based unmount cleanup revokes them without clobbering in-flight URLs).

## Test plan

- [ ] Sign out and reload `/configurator/` — login fields are empty, browser does not prompt to fill saved creds, no "Save password?" banner after a real login.
- [ ] Phase 1.2 Branding — upload an image to any of the four rows, click **Preview** → modal opens with the image. Replace the image → Preview now shows the new image. Close modal, navigate away — no memory leak warnings in the console.
- [ ] Existing Phase-1 flow (upload tenant Excel → preview → branding → complete) still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)