### PR TITLE
employees: fix JsonMappingException on save (closes #439)

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -612,7 +612,24 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         return { data: normalizeMdmsRecord(updated, config) };
       }
       if (config.type === 'hrms') {
-        const [employee] = await client.employeeUpdate(tenantId, [params.data as Record<string, unknown>]);
+        // normalizeRecord overwrote the native numeric `id` with the
+        // uuid string (idField: 'uuid') so react-admin can route by it,
+        // but HRMS's Employee POJO has `id: Long` — sending a string
+        // back makes Jackson throw JsonMappingException (closes #439).
+        // Re-fetch the server record, strip the react-admin `id`, and
+        // merge the form payload onto it so the native Long id (plus
+        // any nested arrays the form never rendered) round-trip intact.
+        const data = params.data as Record<string, unknown>;
+        const uuid = typeof data.uuid === 'string' && data.uuid
+          ? data.uuid
+          : String(params.id);
+        const fetched = await client.employeeSearch(tenantId, { uuids: [uuid] });
+        if (!fetched.length) throw new Error(`Employee not found: ${uuid}`);
+        const base = fetched[0] as Record<string, unknown>;
+        const { id: _stringId, ...rest } = data;
+        void _stringId;
+        const merged: Record<string, unknown> = { ...base, ...rest };
+        const [employee] = await client.employeeUpdate(tenantId, [merged]);
         return { data: normalizeRecord(employee, config) };
       }
       if (config.type === 'pgr') {


### PR DESCRIPTION
## Summary

Closes egovernments/Citizen-Complaint-Resolution-System#439 — Configurator "Save" on `/manage/employees/:id/edit` returns

```
{"code":"JsonMappingException","message":"Failed to deserialize certain JSON fields"}
```

### Root cause
`normalizeRecord` rewrites the top-level `id` on every fetched record to the resource's `idField` (`uuid` for employees) so react-admin can route by it. HRMS's Employee POJO has `id: Long`. On save, react-admin's form echoes the whole record back — including `id: "<uuid-string>"`. Jackson chokes coercing a string into Long and raises JsonMappingException. Gurjeet's repro ("add a role, save") surfaced it, but *any* edit triggers the same path.

### Fix
In the data-provider's `update` handler for `hrms`, re-fetch the server record by uuid, strip the react-admin-injected string `id`, and merge the form payload onto the base. Native numeric `id` survives, and arrays the form never rendered (serviceHistory, education, documents, prior deactivationDetails rows) round-trip intact. Same pattern the deactivate branch at `dataProvider.ts:700-712` already uses.

## Test plan

- [ ] `/manage/employees` → open any employee → Edit → add a role → Save → no `JsonMappingException` 500, record updated, Show page reflects the new role.
- [ ] Same flow but editing name / mobile / status — no regression.
- [ ] Deactivate an employee via row action — still works (separate path, pre-existing re-fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)