### PR TITLE
localization: side-by-side dual-locale view with per-column dropdowns

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -191,9 +191,36 @@ async function pgrGetList(client: DigitApiClient, config: ResourceConfig, tenant
 }
 
 async function localizationGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string, filter?: Record<string, unknown>): Promise<RaRecord[]> {
+  // Side-by-side pivot of two locales. The list view picks the locales via
+  // dropdowns and passes them as `locale` (left column) and `locale2` (right
+  // column). Defaults preserve the previous en_IN-only behavior on the left
+  // and surface sw_KE on the right so Nairobi pilot translators see both
+  // out of the box.
   const module = filter?.module ? String(filter.module) : undefined;
-  const messages = await client.localizationSearch(tenantId, 'en_IN', module);
-  return messages.map((m) => normalizeRecord(m, config));
+  const localeA = filter?.locale ? String(filter.locale) : 'en_IN';
+  const localeB = filter?.locale2 ? String(filter.locale2) : 'sw_KE';
+  const [aMsgs, bMsgs] = await Promise.all([
+    client.localizationSearch(tenantId, localeA, module),
+    localeA === localeB ? Promise.resolve([] as Record<string, unknown>[]) : client.localizationSearch(tenantId, localeB, module),
+  ]);
+  // Pivot keyed by `${code}__${module}` so a code that appears under
+  // multiple modules doesn't get collapsed (real DIGIT data does this).
+  const pivot = new Map<string, Record<string, unknown>>();
+  const upsert = (m: Record<string, unknown>, side: 'A' | 'B') => {
+    const code = String(m.code ?? '');
+    const mod = String(m.module ?? '');
+    const key = `${code}__${mod}`;
+    let row = pivot.get(key);
+    if (!row) {
+      row = { id: key, code, module: mod, message: '', message2: '', locale: localeA, locale2: localeB };
+      pivot.set(key, row);
+    }
+    if (side === 'A') row.message = String(m.message ?? '');
+    else row.message2 = String(m.message ?? '');
+  };
+  for (const m of aMsgs) upsert(m as Record<string, unknown>, 'A');
+  for (const m of bMsgs) upsert(m as Record<string, unknown>, 'B');
+  return Array.from(pivot.values()).map((r) => normalizeRecord(r, config));
 }
 
 async function userGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string, filter?: Record<string, unknown>): Promise<RaRecord[]> {
@@ -507,12 +534,37 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         return { data: normalizeRecord(updatedService, config) };
       }
       if (config.type === 'localization') {
+        // Inline-edit on the pivoted list emits a single row with both
+        // `message` (locale A) and `message2` (locale B). Diff against
+        // previousData to know which side actually changed and upsert only
+        // that locale — saves a round-trip and avoids accidentally clobbering
+        // the other side with a stale value.
         const data = params.data as Record<string, unknown>;
-        const messages = await client.localizationUpsert(tenantId, String(data.locale || 'en_IN'), [
-          { code: String(data.code || params.id), message: String(data.message), module: String(data.module) },
-        ]);
-        if (messages.length) return { data: normalizeRecord(messages[0], config) };
-        return { data: { ...data, id: String(data.code || params.id) } as RaRecord };
+        const prev = (params.previousData ?? {}) as Record<string, unknown>;
+        const code = String(data.code || params.id);
+        const mod = String(data.module ?? '');
+        const localeA = String(data.locale ?? 'en_IN');
+        const localeB = String(data.locale2 ?? 'sw_KE');
+        const writes: Promise<unknown>[] = [];
+        if (data.message !== undefined && data.message !== prev.message) {
+          writes.push(client.localizationUpsert(tenantId, localeA, [
+            { code, message: String(data.message ?? ''), module: mod },
+          ]));
+        }
+        if (data.message2 !== undefined && data.message2 !== prev.message2) {
+          writes.push(client.localizationUpsert(tenantId, localeB, [
+            { code, message: String(data.message2 ?? ''), module: mod },
+          ]));
+        }
+        // Legacy non-pivot callers (Show/Edit individual record pages) only
+        // send `message` + `locale` — the first branch handles them.
+        if (writes.length === 0 && data.message !== undefined) {
+          writes.push(client.localizationUpsert(tenantId, localeA, [
+            { code, message: String(data.message), module: mod },
+          ]));
+        }
+        await Promise.all(writes);
+        return { data: { ...data, id: String(data.id ?? `${code}__${mod}`) } as RaRecord };
       }
       if (config.type === 'boundary') {
         const data = params.data as Record<string, unknown>;

--- a/src/resources/localization/LocalizationList.tsx
+++ b/src/resources/localization/LocalizationList.tsx
@@ -1,25 +1,96 @@
+import { useListContext } from 'ra-core';
 import { DigitList, DigitDatagrid } from '@/admin';
 import type { DigitColumn } from '@/admin';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
-const columns: DigitColumn[] = [
-  { source: 'code', label: 'app.fields.code' },
-  {
-    source: 'message',
-    label: 'app.fields.message',
-    editable: true,
-    render: (record) => {
-      const msg = String(record.message ?? '');
-      return <span className="truncate max-w-[300px] block">{msg.length > 80 ? msg.slice(0, 80) + '...' : msg}</span>;
-    },
-  },
-  { source: 'module', label: 'app.fields.module' },
-  { source: 'locale', label: 'app.fields.locale' },
+/**
+ * Locales offered in the column dropdowns. Curated set rather than every
+ * BCP-47 tag — live DIGIT-UI deployments use these three (en_IN baseline,
+ * sw_KE for the Kenya pilot, hi_IN for India). Extend as needed.
+ */
+const LOCALE_OPTIONS = [
+  { value: 'en_IN', label: 'English (en_IN)' },
+  { value: 'sw_KE', label: 'Swahili (sw_KE)' },
+  { value: 'hi_IN', label: 'Hindi (hi_IN)' },
 ];
+
+const labelFor = (code: string) =>
+  LOCALE_OPTIONS.find((o) => o.value === code)?.label ?? code;
+
+const truncate = (s: unknown) => {
+  const t = String(s ?? '');
+  return t.length > 80 ? t.slice(0, 80) + '…' : t;
+};
+
+/** Two-locale picker rendered above the datagrid. Writes to the list filter
+ *  state — the data provider reads `locale` (left col) + `locale2` (right
+ *  col) and pivots both into one row per (code, module). */
+function LocaleSelector() {
+  const { filterValues, setFilters } = useListContext();
+  const localeA = String(filterValues.locale || 'en_IN');
+  const localeB = String(filterValues.locale2 || 'sw_KE');
+  const update = (key: 'locale' | 'locale2') => (v: string) =>
+    setFilters({ ...filterValues, [key]: v }, undefined, true);
+
+  return (
+    <div className="flex items-center gap-3 mb-3 flex-wrap">
+      <span className="text-xs font-medium text-muted-foreground">Compare locales:</span>
+      <Select value={localeA} onValueChange={update('locale')}>
+        <SelectTrigger className="w-[180px] h-8 text-xs"><SelectValue /></SelectTrigger>
+        <SelectContent>
+          {LOCALE_OPTIONS.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+        </SelectContent>
+      </Select>
+      <span className="text-xs text-muted-foreground">vs</span>
+      <Select value={localeB} onValueChange={update('locale2')}>
+        <SelectTrigger className="w-[180px] h-8 text-xs"><SelectValue /></SelectTrigger>
+        <SelectContent>
+          {LOCALE_OPTIONS.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+        </SelectContent>
+      </Select>
+      {localeA === localeB && (
+        <span className="text-xs text-warning-dark">Same locale on both sides — pick different ones to compare.</span>
+      )}
+    </div>
+  );
+}
+
+/** Datagrid with column labels driven by the locale dropdowns. Rendered
+ *  inside DigitList so it shares the ListContextProvider with the selector. */
+function PivotDatagrid() {
+  const { filterValues } = useListContext();
+  const localeA = String(filterValues.locale || 'en_IN');
+  const localeB = String(filterValues.locale2 || 'sw_KE');
+
+  const columns: DigitColumn[] = [
+    { source: 'code', label: 'app.fields.code' },
+    { source: 'module', label: 'app.fields.module' },
+    {
+      source: 'message',
+      label: `Message · ${labelFor(localeA)}`,
+      editable: true,
+      render: (record) => <span className="block max-w-[300px] truncate">{truncate(record.message)}</span>,
+    },
+    {
+      source: 'message2',
+      label: `Message · ${labelFor(localeB)}`,
+      editable: true,
+      render: (record) => (
+        <span className={`block max-w-[300px] truncate ${record.message2 ? '' : 'italic text-muted-foreground'}`}>
+          {record.message2 ? truncate(record.message2) : '— missing —'}
+        </span>
+      ),
+    },
+  ];
+
+  return <DigitDatagrid columns={columns} />;
+}
 
 export function LocalizationList() {
   return (
     <DigitList title="app.resources.localization" hasCreate sort={{ field: 'code', order: 'ASC' }}>
-      <DigitDatagrid columns={columns} rowClick="show" />
+      <LocaleSelector />
+      <PivotDatagrid />
     </DigitList>
   );
 }


### PR DESCRIPTION
## What

The `/manage/localization` list page hardcoded `en_IN` and offered no way to view another locale. Swahili (and any other locale present in the deployment) was invisible in the configurator even though the `localization` service had thousands of `sw_KE` rows. This PR turns the page into a side-by-side comparator with two locale dropdowns — one per column.

## How it looks

\`\`\`
[ Compare locales: [ English (en_IN) ▾ ]  vs  [ Swahili (sw_KE) ▾ ] ]

| Code              | Module        | Message · en_IN          | Message · sw_KE                |
|-------------------|---------------|--------------------------|--------------------------------|
| HOME_TITLE        | rainmaker-pgr | File a complaint         | Wasilisha malalamiko           |
| ACTION_REOPEN     | rainmaker-pgr | Reopen this complaint    | — missing —                    |
| ...
\`\`\`

Inline-edit each cell — saves only the locale that changed. Missing translations render as `— missing —` so gaps stand out.

## Files

- `packages/data-provider/src/providers/dataProvider.ts`
  - `localizationGetList`: reads `locale` (left) + `locale2` (right) from filter, fetches both in parallel, pivots into one row per `(code, module)` keyed `${code}__${module}` (disambiguates the same code under multiple modules — real DIGIT data hits this).
  - `localization` update path: diffs `data.message` vs `prev.message` and `data.message2` vs `prev.message2` to upsert only the side that changed. Falls back to single-locale upsert for legacy callers (Show/Edit pages).
- `src/resources/localization/LocalizationList.tsx`: rewrite. Two-locale `Select` dropdowns at top driving `setFilters`; `PivotDatagrid` re-renders columns when locales change.

## Defaults

Left = `en_IN`, right = `sw_KE`. Curated locale list `[en_IN, sw_KE, hi_IN]` covers the three real DIGIT-UI deployments today; one-line array push to add more.

## Test plan

- [x] Local build + lint (`tsc -b` + `vite build` clean against the package).
- [ ] Walk `/configurator/manage/localization` on naipepea after deploy:
  - both dropdowns work; columns relabel
  - sw_KE rows actually appear in the right column (this is the regression the PR fixes)
  - inline-edit on left col only changes en_IN
  - inline-edit on right col only changes sw_KE
  - "— missing —" placeholder shows for codes that exist in left locale but not right

🤖 Generated with [Claude Code](https://claude.com/claude-code)