### PR TITLE
localization: source dropdown locales from StateInfo MDMS, not a constant

### DIFF
--- a/src/hooks/useAvailableLocales.ts
+++ b/src/hooks/useAvailableLocales.ts
@@ -1,0 +1,84 @@
+import { useQuery } from '@tanstack/react-query';
+import { digitClient } from '@/providers/bridge';
+
+/**
+ * Hook that returns the locales available for localization editing on the
+ * current session tenant.
+ *
+ * Source of truth (in priority order):
+ *   1. MDMS `common-masters.StateInfo[0].languages` — what the tenant
+ *      formally declares it supports. This is the same source DIGIT-UI
+ *      uses to populate its language switcher.
+ *   2. Curated fallback set if StateInfo is missing/empty so the dropdown
+ *      is never blank — `en_IN` (universal default) plus `default` (DIGIT's
+ *      i18n fallback bucket).
+ *
+ * What this DOESN'T do: probe the localization service for which locales
+ * actually have rows. The localization API requires a `locale` param on
+ * search and offers no enumeration endpoint, so discovery would mean
+ * brute-forcing a candidate set. StateInfo is the correct knob — fix it
+ * for tenants whose data is stale.
+ */
+export interface LocaleOption {
+  value: string;   // e.g. "en_IN"
+  label: string;   // e.g. "English (en_IN)"
+}
+
+const FALLBACK_LOCALES: LocaleOption[] = [
+  { value: 'en_IN', label: 'English (en_IN)' },
+  { value: 'default', label: 'Default (default)' },
+];
+
+// Friendly labels keyed by BCP-47-ish DIGIT codes. Falls back to
+// the StateInfo `label` if present, else the raw value.
+const NICE_NAME: Record<string, string> = {
+  en_IN: 'English',
+  sw_KE: 'Swahili',
+  hi_IN: 'Hindi',
+  ka_IN: 'Kannada',
+  ta_IN: 'Tamil',
+  te_IN: 'Telugu',
+  default: 'Default',
+};
+
+function formatLabel(value: string, label?: string): string {
+  const friendly = NICE_NAME[value] ?? label ?? value;
+  return `${friendly} (${value})`;
+}
+
+export function useAvailableLocales(): {
+  locales: LocaleOption[];
+  isLoading: boolean;
+  error: Error | null;
+} {
+  const tenantId = digitClient.stateTenantId;
+
+  const { data, isLoading, error } = useQuery<LocaleOption[], Error>({
+    queryKey: ['available-locales', tenantId],
+    queryFn: async () => {
+      if (!tenantId) return FALLBACK_LOCALES;
+      const records = await digitClient.mdmsSearch(tenantId, 'common-masters.StateInfo', { limit: 1 });
+      const stateInfo = records.find((r) => r.isActive)?.data as Record<string, unknown> | undefined;
+      const langs = Array.isArray(stateInfo?.languages) ? stateInfo!.languages as Array<{ value?: string; label?: string }> : [];
+      const fromStateInfo: LocaleOption[] = langs
+        .filter((l): l is { value: string; label?: string } => typeof l?.value === 'string')
+        .map((l) => ({ value: l.value, label: formatLabel(l.value, l.label) }));
+      // Always include `default` since DIGIT consumers fall back to it when a
+      // tenant locale is missing — translators want to edit it directly.
+      const seen = new Set(fromStateInfo.map((l) => l.value));
+      if (!seen.has('default')) {
+        fromStateInfo.push({ value: 'default', label: formatLabel('default') });
+      }
+      return fromStateInfo.length > 0 ? fromStateInfo : FALLBACK_LOCALES;
+    },
+    staleTime: 10 * 60 * 1000, // 10 minutes — StateInfo doesn't change often
+    gcTime: 10 * 60 * 1000,
+    enabled: !!tenantId,
+  });
+
+  return {
+    locales: data ?? FALLBACK_LOCALES,
+    isLoading,
+    error: error ?? null,
+  };
+}

--- a/src/resources/localization/LocalizationList.tsx
+++ b/src/resources/localization/LocalizationList.tsx
@@ -2,20 +2,10 @@ import { useListContext } from 'ra-core';
 import { DigitList, DigitDatagrid } from '@/admin';
 import type { DigitColumn } from '@/admin';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useAvailableLocales, type LocaleOption } from '@/hooks/useAvailableLocales';
 
-/**
- * Locales offered in the column dropdowns. Curated set rather than every
- * BCP-47 tag — live DIGIT-UI deployments use these three (en_IN baseline,
- * sw_KE for the Kenya pilot, hi_IN for India). Extend as needed.
- */
-const LOCALE_OPTIONS = [
-  { value: 'en_IN', label: 'English (en_IN)' },
-  { value: 'sw_KE', label: 'Swahili (sw_KE)' },
-  { value: 'hi_IN', label: 'Hindi (hi_IN)' },
-];
-
-const labelFor = (code: string) =>
-  LOCALE_OPTIONS.find((o) => o.value === code)?.label ?? code;
+const labelFor = (code: string, locales: LocaleOption[]) =>
+  locales.find((o) => o.value === code)?.label ?? code;
 
 const truncate = (s: unknown) => {
   const t = String(s ?? '');
@@ -27,25 +17,31 @@ const truncate = (s: unknown) => {
  *  col) and pivots both into one row per (code, module). */
 function LocaleSelector() {
   const { filterValues, setFilters } = useListContext();
-  const localeA = String(filterValues.locale || 'en_IN');
-  const localeB = String(filterValues.locale2 || 'sw_KE');
+  const { locales, isLoading } = useAvailableLocales();
+
+  // Defaults: first locale on the left, second locale on the right (or
+  // duplicate when only one is registered). Honors any user choice in URL/state.
+  const fallbackA = locales[0]?.value ?? 'en_IN';
+  const fallbackB = locales[1]?.value ?? locales[0]?.value ?? 'en_IN';
+  const localeA = String(filterValues.locale || fallbackA);
+  const localeB = String(filterValues.locale2 || fallbackB);
   const update = (key: 'locale' | 'locale2') => (v: string) =>
     setFilters({ ...filterValues, [key]: v }, undefined, true);
 
   return (
     <div className="flex items-center gap-3 mb-3 flex-wrap">
       <span className="text-xs font-medium text-muted-foreground">Compare locales:</span>
-      <Select value={localeA} onValueChange={update('locale')}>
-        <SelectTrigger className="w-[180px] h-8 text-xs"><SelectValue /></SelectTrigger>
+      <Select value={localeA} onValueChange={update('locale')} disabled={isLoading}>
+        <SelectTrigger className="w-[200px] h-8 text-xs"><SelectValue placeholder={isLoading ? 'loading…' : 'pick locale'} /></SelectTrigger>
         <SelectContent>
-          {LOCALE_OPTIONS.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+          {locales.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
         </SelectContent>
       </Select>
       <span className="text-xs text-muted-foreground">vs</span>
-      <Select value={localeB} onValueChange={update('locale2')}>
-        <SelectTrigger className="w-[180px] h-8 text-xs"><SelectValue /></SelectTrigger>
+      <Select value={localeB} onValueChange={update('locale2')} disabled={isLoading}>
+        <SelectTrigger className="w-[200px] h-8 text-xs"><SelectValue placeholder={isLoading ? 'loading…' : 'pick locale'} /></SelectTrigger>
         <SelectContent>
-          {LOCALE_OPTIONS.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
+          {locales.map((o) => <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>)}
         </SelectContent>
       </Select>
       {localeA === localeB && (
@@ -59,21 +55,24 @@ function LocaleSelector() {
  *  inside DigitList so it shares the ListContextProvider with the selector. */
 function PivotDatagrid() {
   const { filterValues } = useListContext();
-  const localeA = String(filterValues.locale || 'en_IN');
-  const localeB = String(filterValues.locale2 || 'sw_KE');
+  const { locales } = useAvailableLocales();
+  const fallbackA = locales[0]?.value ?? 'en_IN';
+  const fallbackB = locales[1]?.value ?? locales[0]?.value ?? 'en_IN';
+  const localeA = String(filterValues.locale || fallbackA);
+  const localeB = String(filterValues.locale2 || fallbackB);
 
   const columns: DigitColumn[] = [
     { source: 'code', label: 'app.fields.code' },
     { source: 'module', label: 'app.fields.module' },
     {
       source: 'message',
-      label: `Message · ${labelFor(localeA)}`,
+      label: `Message · ${labelFor(localeA, locales)}`,
       editable: true,
       render: (record) => <span className="block max-w-[300px] truncate">{truncate(record.message)}</span>,
     },
     {
       source: 'message2',
-      label: `Message · ${labelFor(localeB)}`,
+      label: `Message · ${labelFor(localeB, locales)}`,
       editable: true,
       render: (record) => (
         <span className={`block max-w-[300px] truncate ${record.message2 ? '' : 'italic text-muted-foreground'}`}>


### PR DESCRIPTION
## What

Builds on PR #32. The two-locale dropdowns previously used a hardcoded `[en_IN, sw_KE, hi_IN]` triple, which won't survive any future deployment with a different locale set.

This PR reads available locales from MDMS `common-masters.StateInfo[0].languages` — the same source DIGIT-UI uses for its language switcher. New hook `useAvailableLocales` returns options derived from StateInfo, falls back gracefully if StateInfo is empty, and is cached for 10 minutes via react-query.

## Why MDMS, not a discovery probe

The localization service has no enumeration endpoint — `/messages/v1/_search` requires `locale` as a parameter. The only way to discover what locales exist would be to brute-force a candidate set. StateInfo is the canonical place tenants declare their supported locales; if it's wrong for a deployment, fix StateInfo there (which is itself editable via this same configurator under `/manage/state-info`).

## Files

- `src/hooks/useAvailableLocales.ts` — new hook (~80 lines including header comment)
- `src/resources/localization/LocalizationList.tsx` — replaces the const `LOCALE_OPTIONS` with the hook's output, threads it into both `LocaleSelector` and `PivotDatagrid` for column labels

## Friendly labels

Curated map for known locale codes (`en_IN → English`, `sw_KE → Swahili`, `hi_IN → Hindi`, `ka_IN → Kannada`, `ta_IN → Tamil`, `te_IN → Telugu`, `default → Default`). Falls back to the StateInfo `label` field, then the raw value. Easy to extend.

## Companion data fix (already applied to naipepea)

Naipepea's `StateInfo.languages` was leftover from the DIGIT default seed: `[{label:"ENGLISH", value:"en_IN"}, {label:"ಕನ್ನಡ", value:"ka_IN"}]` — Kannada in a Kenyan deployment. Updated via the MDMS update API to `[{label:"English", value:"en_IN"}, {label:"Swahili", value:"sw_KE"}]` so the dropdown reflects what's actually in the message DB.

## Test plan

- [ ] `/configurator/manage/localization` on naipepea: dropdown shows English, Swahili, Default — not the old hardcoded Hindi
- [ ] Switching the right column to Swahili populates the missing-translation rendering correctly
- [ ] Network tab shows exactly one MDMS call to `common-masters.StateInfo` per session (cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)