### PR TITLE
fix(employees): honour form-picked tenantId in Create transform

### DIFF
--- a/src/resources/employees/EmployeeCreate.tsx
+++ b/src/resources/employees/EmployeeCreate.tsx
@@ -65,6 +65,18 @@ export function EmployeeCreate() {
   };
 
   const transform = (data: Record<string, unknown>): Record<string, unknown> => {
+    // Prefer the form-picked tenantId over the session tenant. The outer
+    // closure `tenantId` is the session tenant (e.g. root `ke` for ADMIN);
+    // letting it shadow `data.tenantId` here was the reason every Create
+    // landed in the session tenant no matter which tenant the operator
+    // picked in the form. The dataProvider already reads `data.tenantId`
+    // correctly (PR #31) — this transform was silently clobbering the
+    // form value before it ever reached the provider.
+    const targetTenantId =
+      typeof data.tenantId === 'string' && data.tenantId.trim()
+        ? data.tenantId.trim()
+        : tenantId;
+
     const userInput = (data.user as Record<string, unknown> | undefined) ?? {};
     const name = typeof userInput.name === 'string' ? userInput.name.trim() : '';
     const userName =
@@ -74,7 +86,7 @@ export function EmployeeCreate() {
     const user = {
       ...userInput,
       userName,
-      tenantId,
+      tenantId: targetTenantId,
       type: 'EMPLOYEE',
       active: true,
       password: typeof userInput.password === 'string' && userInput.password ? userInput.password : DEFAULT_PASSWORD,
@@ -85,7 +97,7 @@ export function EmployeeCreate() {
 
     return {
       ...data,
-      tenantId,
+      tenantId: targetTenantId,
       dateOfAppointment: doa,
       user,
     };


### PR DESCRIPTION
## Problem

On https://naipepea.digit.org/configurator/manage/employees/create, a root-`ke` ADMIN picks `Nairobi City (ke.nairobi)` from the Tenant dropdown, saves, and the new employee lands at **root `ke`** instead. Every Create did this regardless of picker choice.

## Root cause

`EmployeeCreate.transform` was running:

```ts
return { ...data, tenantId, user: { ..., tenantId } }
```

where `tenantId` is the closure from `const tenantId = state.tenant` at the top of the component — i.e. the **session** tenant. That shadowed `data.tenantId` (which carries the dropdown's value) before the record ever reached the dataProvider.

The dataProvider's HRMS branch already prefers `data.tenantId` (PR #31), so the provider wasn't the problem — the form transform was clobbering the value upstream.

## Fix

Compute a `targetTenantId` once at the top of `transform`:

```ts
const targetTenantId =
  typeof data.tenantId === 'string' && data.tenantId.trim()
    ? data.tenantId.trim()
    : tenantId;
```

Stamp it on both the outer record and the nested `user.tenantId`. Falls back to the session tenant only when the form omits `tenantId`.

## QA

1. Log in to configurator as root (`ADMIN` on `ke`).
2. Manage Employees → Create.
3. Tenant dropdown → pick `ke.nairobi`.
4. Fill name / DOB / roles / department → Save.
5. Open the new record — `Tenant` column should read `ke.nairobi`, not `ke`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tenant selection in the employee creation form to respect the user's chosen tenant instead of reverting to the session tenant during submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->