### PR TITLE
fix(undo): hide misleading Undo toast until rollback compensators exist

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,15 @@ import PgrDashboard from './pages/PgrDashboard';
 import { getGenericMdmsResources, getDataProvider, getAuthProvider, configureDigitClient, digitClient, resetProviders, i18nProvider } from '@/providers/bridge';
 import { ThemeProvider } from '@/providers/ThemeProvider';
 import HelpModal from './components/ui/HelpModal';
-import UndoToast from './components/ui/UndoToast';
+// UndoToast removed — see CCRS#417. The previous Undo button only popped
+// the local UI stack; egov-mdms-service exposes no `_delete`/`_disable`
+// endpoint, so there is no real way to roll back a created tenant +
+// branding + localization rows from this UI today. The button promised
+// rollback it couldn't deliver, so we hide it until the backend grows
+// proper compensators (or until product defines a different semantic for
+// "Undo" — e.g. soft-deactivate via `_update isActive=false` for schemas
+// without unique-key collisions).
+// import UndoToast from './components/ui/UndoToast';
 import { Toaster } from './components/ui/toaster';
 import { apiClient, getApiBaseUrl } from './api';
 import { identifyUser, clearUser, trackEvent } from './lib/telemetry';
@@ -445,7 +453,7 @@ function App() {
 
         {/* Global modals and toasts */}
         {state.showHelp && <HelpModal onClose={toggleHelp} />}
-        <UndoToast items={state.undoStack} onUndo={undo} onDismiss={dismissUndo} />
+        {/* <UndoToast items={state.undoStack} onUndo={undo} onDismiss={dismissUndo} /> */}
         <Toaster />
       </BrowserRouter>
       </ThemeProvider>


### PR DESCRIPTION
Closes UI half of egovernments/CCRS#417.

## Problem
The Phase-1 onboarding flow showed an 'Undo' toast that only popped the in-memory UI stack — the just-created tenant, branding, and localization rows stayed in the backend. Clicking it gave no feedback and no rollback.

## Why we can't fix it properly today
- `mdms-v2/v2/_delete` → 404 (no endpoint exists).
- `mdms-v2/v2/_disable` / `_remove` → 404.
- `mdms-v2/v2/_update` exists, but rejects payloads that include any field declared `x-unique` in the schema (e.g. `code`, `name` on common-masters.StateInfo). So even soft-delete via `isActive: false` is blocked for schemas with unique-key constraints.

## Fix
Comment out the `<UndoToast>` render and the import. The undo stack itself stays in state (Ctrl+Z is still wired) so once a real rollback path exists, we flip the render back on without rebuilding the stack.

## Asks raised in the issue comment
1. Backend: add `_delete` (or `_disable`) to mdms-v2; or relax `_update`'s unique-field rejection to allow same-value updates.
2. Product: confirm what 'Undo' should actually mean here — true rollback, or just dismiss the toast?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the undo notification toast that was previously displayed to users during undo operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->