### PR TITLE
fix(employees): drop duplicate Username field on Create form

### DIFF
--- a/src/resources/employees/EmployeeCreate.tsx
+++ b/src/resources/employees/EmployeeCreate.tsx
@@ -26,14 +26,6 @@ const TYPE_CHOICES = [
   { value: 'DEPUTATION', label: 'Deputation' },
 ];
 
-function deriveUsername(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, '.')
-    .replace(/\.+/g, '.')
-    .replace(/^\.|\.$/g, '');
-}
-
 function toEpochMs(value: unknown): number | undefined {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string' && value) {
@@ -78,14 +70,10 @@ export function EmployeeCreate() {
         : tenantId;
 
     const userInput = (data.user as Record<string, unknown> | undefined) ?? {};
-    const name = typeof userInput.name === 'string' ? userInput.name.trim() : '';
-    const userName =
-      typeof userInput.userName === 'string' && userInput.userName.trim()
-        ? userInput.userName.trim().toLowerCase()
-        : deriveUsername(name);
+    const code = typeof data.code === 'string' ? data.code.trim() : '';
     const user = {
       ...userInput,
-      userName,
+      userName: code.toLowerCase(),
       tenantId: targetTenantId,
       type: 'EMPLOYEE',
       active: true,
@@ -132,11 +120,6 @@ export function EmployeeCreate() {
             label="Mobile Number"
             validate={mobileValidate}
             help={mobileRules.errorMessage}
-          />
-          <DigitFormInput
-            source="user.userName"
-            label="Username"
-            help="Auto-generated from name if left blank"
           />
           <DigitFormInput source="user.emailId" label="Email" type="email" validate={v.emailOptional} />
           <DigitFormInput source="user.dob" label="Date of Birth" type="date" validate={v.required} />


### PR DESCRIPTION
Closes egovernments/Citizen-Complaint-Resolution-System#460.

## Summary
- Remove the **Username** input from the Create Employee form — it shadowed **Employee Code** because HRMS stores `user.userName == employee.code` on every record (and uppercases whatever the client sends).
- Replace the old `deriveUsername(name)` fallback in the transform with `userName = code.toLowerCase()`. HRMS still uppercases on write, so the stored record matches what existed before.

## Why
The field was visually duplicate — operators saw the same auto-derived value in both places, and submitting different strings still ended up with `userName == code` on the detail page (per the bug video). Removing the field eliminates the confusion without changing the stored data.

## API validation
Reproduced the new transform's payload shape against naipepea:

```
POST /egov-hrms/employees/_create
  user.userName = "emp-dedup-fix-002"   # lowercased code
  code           = "EMP-DEDUP-FIX-002"
→ HTTP 200, employee 14bbb35a-… created with user.userName="EMP-DEDUP-FIX-002"
```

Existing records confirm the same invariant — e.g. `EMP-KE_NAIROBI-000001` (Patrick Mbogo) has `user.userName = "EMP-KE_NAIROBI-000001"`.

## Out of scope
- `EmployeeEdit.tsx` already shows Username as `disabled` and `EmployeeShow.tsx` only displays it; both stay as-is (read-only views are useful for verifying the stored value).
- `EmployeeBulkImport.tsx` keeps its optional `userName` column (CSV power-users may want to override before HRMS uppercases).

## Test plan
- [ ] Open `/configurator/manage/employees/create` — only **Employee Code** appears, no Username field.
- [ ] Submit with a fresh code — record lands with `user.userName == code` on the detail page.
- [ ] Bulk import CSV still accepts/derives `userName` as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Form Improvements**
  * Streamlined the employee creation form by removing the dedicated username input field. Usernames are now automatically generated from employee codes, reducing data entry complexity and ensuring consistent username formatting across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->