### PR TITLE
feat(theme): trim Theme Config form to 13 v2 semantic inputs

### DIFF
--- a/src/admin/schemaDescriptors/theme-config.ts
+++ b/src/admin/schemaDescriptors/theme-config.ts
@@ -1,72 +1,46 @@
 import type { SchemaDescriptor } from './types';
 
 /**
- * Descriptor for `common-masters.ThemeConfig` — the per-tenant UI color palette
- * (e.g. the "kenya-green" record driving Nairobi's green/red DIGIT theme).
+ * Descriptor for `common-masters.ThemeConfig` — v2 semantic shape.
  *
- * The JSON Schema declares `colors` as an untyped `type: "object"`, so the
- * default auto-form would skip it entirely. The live records, however, carry
- * a deep tree of named color tokens (primary, link, text, grey, alerts,
- * digitv2 chart/alert tokens, etc). This descriptor expands every leaf color
- * into its own `color` widget addressed by a dot path (e.g. `colors.primary.main`).
+ * The runtime applyTheme.js (theflywheel/digit-ui-esbuild#66) expands these
+ * 13 flat semantic keys into the 30+ CSS variables the existing CSS consumes,
+ * so a tenant theme is now captured in roughly a dozen inputs instead of 35+.
+ * That is what makes the "ship to a new client in a day" onboarding goal
+ * practical.
  *
- * Parent objects (`colors`, `colors.primary`, ...) are intentionally NOT listed
- * as fields — the generic fallback skips them, which is what we want. Only the
- * string-valued leaves are editable.
+ * Old v1 records (nested groups like `colors.primary.main`) continue to
+ * render correctly at runtime via the legacy v1 flatten path — they just
+ * aren't editable through this trimmed form. Either re-enter the values as
+ * v2 to migrate, or edit the raw JSON via MDMS API.
+ *
+ * Each input fans out to the CSS vars listed beside it; the help text
+ * describes the surface effect, not the var names, so admins don't need to
+ * know the underlying token taxonomy.
  */
 export const themeConfigDescriptor: SchemaDescriptor = {
   schema: 'common-masters.ThemeConfig',
   customEditor: 'theme-config',
   groups: [
     { title: 'Identity', fields: ['code', 'name', 'version'] },
-    { title: 'Primary / Link', fields: [
-      'colors.primary.main',
-      'colors.primary.dark',
-      'colors.primary.light',
-      'colors.primary.accent',
-      'colors.primary.selected-bg',
-      'colors.link.normal',
-      'colors.link.hover',
-      'colors.secondary',
+    { title: 'Brand & Surface', fields: [
+      'colors.brand',
+      'colors.brand-on',
+      'colors.surface-header',
+      'colors.surface-page',
+      'colors.selected-bg',
+    ] },
+    { title: 'Text & Borders', fields: [
+      'colors.text-primary',
+      'colors.text-secondary',
+      'colors.text-disabled',
       'colors.border',
-      'colors.input-border',
     ] },
-    { title: 'Text', fields: [
-      'colors.text.primary',
-      'colors.text.secondary',
-      'colors.text.heading',
-      'colors.text.muted',
-    ] },
-    { title: 'Grey', fields: [
-      'colors.grey.light',
-      'colors.grey.lighter',
-      'colors.grey.bg',
-      'colors.grey.mid',
-      'colors.grey.dark',
-      'colors.grey.disabled',
-    ] },
-    { title: 'Alerts & Status', fields: [
-      'colors.success',
+    { title: 'Status', fields: [
       'colors.error',
-      'colors.error-dark',
-      'colors.info-dark',
-      'colors.warning-dark',
-    ] },
-    { title: 'Charts', fields: [
-      'colors.digitv2.chart-1',
-      'colors.digitv2.chart-2',
-      'colors.digitv2.chart-3',
-      'colors.digitv2.chart-4',
-      'colors.digitv2.chart-5',
-    ] },
-    { title: 'DigitV2 tokens', fields: [
-      'colors.digitv2.primary-bg',
-      'colors.digitv2.header-sidenav',
-      'colors.digitv2.alert-info',
-      'colors.digitv2.alert-info-bg',
-      'colors.digitv2.alert-error-bg',
-      'colors.digitv2.alert-success-bg',
-      'colors.digitv2.text-color-disabled',
+      'colors.success',
+      'colors.info',
+      'colors.warning',
     ] },
   ],
   fields: [
@@ -76,92 +50,38 @@ export const themeConfigDescriptor: SchemaDescriptor = {
     { path: 'name', widget: 'text',
       help: 'Human-readable theme name shown in admin UIs.' },
     { path: 'version', widget: 'text',
-      help: 'Optional version string, e.g. "1.0.0". Bump when shipping breaking token changes.' },
+      help: 'Schema version — set to "2" for new themes (semantic shape).' },
 
-    // --- Primary / Link ---
-    { path: 'colors.primary.main', widget: 'color', label: 'Primary / main',
-      help: 'The brand color — buttons, highlights, active nav.' },
-    { path: 'colors.primary.dark', widget: 'color', label: 'Primary / dark',
-      help: 'Darker shade of primary, used for hover / pressed states.' },
-    { path: 'colors.primary.light', widget: 'color', label: 'Primary / light',
-      help: 'Lighter shade of primary, used for soft backgrounds.' },
-    { path: 'colors.primary.accent', widget: 'color', label: 'Primary / accent',
-      help: 'Secondary accent color paired with primary (e.g. the red in kenya-green).' },
-    { path: 'colors.primary.selected-bg', widget: 'color', label: 'Primary / selected-bg',
-      help: 'Background tint for selected rows / active menu items.' },
-    { path: 'colors.link.normal', widget: 'color', label: 'Link / normal',
-      help: 'Default anchor color.' },
-    { path: 'colors.link.hover', widget: 'color', label: 'Link / hover',
-      help: 'Anchor color on hover / focus.' },
-    { path: 'colors.secondary', widget: 'color',
-      help: 'Secondary brand color, typically used for headings / dark UI.' },
-    { path: 'colors.border', widget: 'color',
-      help: '1px divider color, e.g. between rows in a table.' },
-    { path: 'colors.input-border', widget: 'color',
-      help: 'Border color for form inputs in their default (unfocused) state.' },
+    // --- Brand & Surface ---
+    { path: 'colors.brand', widget: 'color', label: 'Brand',
+      help: 'The primary brand color — buttons, highlights, active nav, focus rings. The most prominent color in the UI.' },
+    { path: 'colors.brand-on', widget: 'color', label: 'Brand-on',
+      help: 'The accent paired with brand — links, headings, button hover/pressed states. Usually a contrasting hue (e.g. dark green when brand is amber).' },
+    { path: 'colors.surface-header', widget: 'color', label: 'Surface / header',
+      help: 'Background of the top header bar and side navigation rail.' },
+    { path: 'colors.surface-page', widget: 'color', label: 'Surface / page',
+      help: 'Page background behind cards and panels. Usually a near-white grey.' },
+    { path: 'colors.selected-bg', widget: 'color', label: 'Selected-bg',
+      help: 'Soft tint for selected rows, active menu items, picked dropdown options. Typically a light wash of brand.' },
 
-    // --- Text ---
-    { path: 'colors.text.primary', widget: 'color', label: 'Text / primary',
-      help: 'Main body text color.' },
-    { path: 'colors.text.secondary', widget: 'color', label: 'Text / secondary',
-      help: 'De-emphasized text (captions, metadata).' },
-    { path: 'colors.text.heading', widget: 'color', label: 'Text / heading',
-      help: 'Color for h1–h6 headings.' },
-    { path: 'colors.text.muted', widget: 'color', label: 'Text / muted',
-      help: 'Faintest text — placeholders, disabled labels.' },
+    // --- Text & Borders ---
+    { path: 'colors.text-primary', widget: 'color', label: 'Text / primary',
+      help: 'Default body text — paragraphs, table cells, form values.' },
+    { path: 'colors.text-secondary', widget: 'color', label: 'Text / secondary',
+      help: 'De-emphasized text — captions, metadata, helper text, placeholders.' },
+    { path: 'colors.text-disabled', widget: 'color', label: 'Text / disabled',
+      help: 'Text and icon color for disabled buttons, inputs, and menu items.' },
+    { path: 'colors.border', widget: 'color', label: 'Border',
+      help: 'Hairlines: card borders, table dividers, input borders, divider lines.' },
 
-    // --- Grey scale ---
-    { path: 'colors.grey.light', widget: 'color', label: 'Grey / light',
-      help: 'Lightest grey — page background.' },
-    { path: 'colors.grey.lighter', widget: 'color', label: 'Grey / lighter',
-      help: 'Slightly darker than `light`; section dividers / zebra rows.' },
-    { path: 'colors.grey.bg', widget: 'color', label: 'Grey / bg',
-      help: 'Neutral card / panel background.' },
-    { path: 'colors.grey.mid', widget: 'color', label: 'Grey / mid',
-      help: 'Mid grey for subtle borders / rule lines.' },
-    { path: 'colors.grey.dark', widget: 'color', label: 'Grey / dark',
-      help: 'Darker grey for icons and secondary chrome.' },
-    { path: 'colors.grey.disabled', widget: 'color', label: 'Grey / disabled',
-      help: 'Fill color for disabled buttons and inputs.' },
-
-    // --- Alerts & Status ---
-    { path: 'colors.success', widget: 'color',
-      help: 'Success / positive state (checkmarks, success toasts).' },
-    { path: 'colors.error', widget: 'color',
-      help: 'Error / destructive state (validation errors, delete buttons).' },
-    { path: 'colors.error-dark', widget: 'color',
-      help: 'Darker error shade — hover state for error buttons / text.' },
-    { path: 'colors.info-dark', widget: 'color',
-      help: 'Darker info shade — used on info text over light backgrounds.' },
-    { path: 'colors.warning-dark', widget: 'color',
-      help: 'Darker warning shade — used on warning text over light backgrounds.' },
-
-    // --- Charts (digitv2) ---
-    { path: 'colors.digitv2.chart-1', widget: 'color', label: 'DigitV2 / chart-1',
-      help: 'First series color in charts (bars, lines, pie slice 1).' },
-    { path: 'colors.digitv2.chart-2', widget: 'color', label: 'DigitV2 / chart-2',
-      help: 'Second chart series color.' },
-    { path: 'colors.digitv2.chart-3', widget: 'color', label: 'DigitV2 / chart-3',
-      help: 'Third chart series color.' },
-    { path: 'colors.digitv2.chart-4', widget: 'color', label: 'DigitV2 / chart-4',
-      help: 'Fourth chart series color.' },
-    { path: 'colors.digitv2.chart-5', widget: 'color', label: 'DigitV2 / chart-5',
-      help: 'Fifth chart series color.' },
-
-    // --- DigitV2 UI tokens ---
-    { path: 'colors.digitv2.primary-bg', widget: 'color', label: 'DigitV2 / primary-bg',
-      help: 'Tinted background paired with primary — e.g. selected-card fill.' },
-    { path: 'colors.digitv2.header-sidenav', widget: 'color', label: 'DigitV2 / header-sidenav',
-      help: 'Background color for the top header and side navigation rail.' },
-    { path: 'colors.digitv2.alert-info', widget: 'color', label: 'DigitV2 / alert-info',
-      help: 'Info alert accent / icon color.' },
-    { path: 'colors.digitv2.alert-info-bg', widget: 'color', label: 'DigitV2 / alert-info-bg',
-      help: 'Info alert background fill.' },
-    { path: 'colors.digitv2.alert-error-bg', widget: 'color', label: 'DigitV2 / alert-error-bg',
-      help: 'Error alert background fill.' },
-    { path: 'colors.digitv2.alert-success-bg', widget: 'color', label: 'DigitV2 / alert-success-bg',
-      help: 'Success alert background fill.' },
-    { path: 'colors.digitv2.text-color-disabled', widget: 'color', label: 'DigitV2 / text-color-disabled',
-      help: 'Text color used on disabled controls in the DigitV2 component set.' },
+    // --- Status ---
+    { path: 'colors.error', widget: 'color', label: 'Error',
+      help: 'Validation errors, destructive actions, error toasts and badges.' },
+    { path: 'colors.success', widget: 'color', label: 'Success',
+      help: 'Successful state — checkmarks, success toasts, confirmation badges.' },
+    { path: 'colors.info', widget: 'color', label: 'Info',
+      help: 'Informational alerts and badges — neutral attention.' },
+    { path: 'colors.warning', widget: 'color', label: 'Warning',
+      help: 'Warning alerts and badges — caution but not destructive.' },
   ],
 };

--- a/src/admin/themeEditor/ThemePreview.tsx
+++ b/src/admin/themeEditor/ThemePreview.tsx
@@ -18,6 +18,44 @@ function flatten(obj: unknown, prefix = ''): Record<string, string> {
   return out;
 }
 
+/**
+ * Mirror of the runtime SEMANTIC_EXPANSION (theflywheel/digit-ui-esbuild
+ * src/theme/applyTheme.js): each v2 input back-fills the legacy v1 paths the
+ * preview already targets. The preview was built against v1 paths; rather
+ * than rewrite every `data-token` attribute, we project v2 → v1 here so a
+ * Brand/Brand-on/Surface-header/etc. value flows into all the v1 paths the
+ * preview already reads.
+ */
+const V2_TO_V1_FALLBACK: Record<string, string[]> = {
+  brand: ['primary.main'],
+  'brand-on': ['primary.dark', 'primary.accent', 'link.normal', 'link.hover', 'text.heading'],
+  'surface-header': ['secondary', 'digitv2.header-sidenav'],
+  'surface-page': ['grey.light'],
+  'text-primary': ['text.primary'],
+  'text-secondary': ['text.secondary', 'text.muted'],
+  'text-disabled': ['grey.disabled', 'digitv2.text-color-disabled'],
+  border: ['border', 'input-border'],
+  error: ['error', 'error-dark'],
+  success: ['success'],
+  info: ['digitv2.alert-info', 'info-dark'],
+  warning: ['warning-dark'],
+  'selected-bg': ['primary.selected-bg', 'digitv2.primary-bg'],
+};
+
+/** Apply v2 → v1 fan-out so the preview reads consistent values whether the
+ *  admin is entering v1 (legacy) or v2 (semantic) keys. v2 wins on overlap.
+ *  Mirrors applyTheme.js's two-pass behavior. */
+function expandV2(flat: Record<string, string>): Record<string, string> {
+  const out = { ...flat };
+  for (const [v2Key, v1Paths] of Object.entries(V2_TO_V1_FALLBACK)) {
+    const value = flat[v2Key];
+    if (typeof value === 'string' && value) {
+      for (const v1Path of v1Paths) out[v1Path] = value;
+    }
+  }
+  return out;
+}
+
 /** Token helper: read `colors.<path>` with a safe default for empty cells. */
 function tk(flat: Record<string, string>, path: string, fallback: string): string {
   return flat[path] || fallback;
@@ -39,7 +77,10 @@ export function ThemePreview() {
   const colors = useWatch({ name: 'colors' });
   const hover = useHoverContext();
 
-  const flat = useMemo(() => flatten(colors), [colors]);
+  // First flatten the form record, then fan v2 semantic keys into the v1
+  // paths the preview was originally built against. Either entry shape now
+  // drives the preview consistently.
+  const flat = useMemo(() => expandV2(flatten(colors)), [colors]);
 
   // Chart bars — heights are hard-coded; colors come from chart-1..5.
   const chart = [

--- a/src/admin/themeEditor/hoverContext.ts
+++ b/src/admin/themeEditor/hoverContext.ts
@@ -16,6 +16,40 @@ export interface HoverContextValue {
 
 const HIGHLIGHT_CLASS = 'theme-token-hover';
 
+/**
+ * v2 semantic key → list of v1 paths it fans out to. Mirrors the
+ * SEMANTIC_EXPANSION map in theflywheel/digit-ui-esbuild's applyTheme.js
+ * and the V2_TO_V1_FALLBACK map in ThemePreview. Kept here so a hover on a
+ * v2 form input lights up every v1 [data-token] element it ultimately drives.
+ *
+ * Keys are without the `colors.` prefix; the matcher adds it back.
+ */
+const V2_TO_V1: Record<string, string[]> = {
+  brand: ['primary.main'],
+  'brand-on': ['primary.dark', 'primary.accent', 'link.normal', 'link.hover', 'text.heading'],
+  'surface-header': ['secondary', 'digitv2.header-sidenav'],
+  'surface-page': ['grey.light'],
+  'text-primary': ['text.primary'],
+  'text-secondary': ['text.secondary', 'text.muted'],
+  'text-disabled': ['grey.disabled', 'digitv2.text-color-disabled'],
+  border: ['border', 'input-border'],
+  error: ['error', 'error-dark'],
+  success: ['success'],
+  info: ['digitv2.alert-info', 'info-dark'],
+  warning: ['warning-dark'],
+  'selected-bg': ['primary.selected-bg', 'digitv2.primary-bg'],
+};
+
+/** Tokens to look for given a hovered form field path. For a v2 form input
+ *  (`colors.brand`), returns the v2 path itself plus every v1 path the v2 key
+ *  expands to. For a legacy v1 path or any non-v2 token, returns it unchanged. */
+function expandTokenForMatching(token: string): string[] {
+  const v2Key = token.startsWith('colors.') ? token.slice('colors.'.length) : token;
+  const v1Paths = V2_TO_V1[v2Key];
+  if (!v1Paths) return [token];
+  return [token, ...v1Paths.map((p) => `colors.${p}`)];
+}
+
 const HoverContext = createContext<HoverContextValue | null>(null);
 
 export function useHoverContext(): HoverContextValue | null {
@@ -44,10 +78,13 @@ export function useCreateHoverContext(): HoverContextValue {
     // CSS attribute selectors can't have escaped commas / colons without quoting,
     // so we filter by exact match against the full token path stored on data-token.
     // Multiple tokens on one element are space-separated (e.g. "colors.border colors.input-border").
+    // For a v2 input (e.g. colors.brand), we also light up any element whose
+    // data-token contains the v1 paths brand fans out into (colors.primary.main, …).
+    const candidates = expandTokenForMatching(token);
     const matches = Array.from(root.querySelectorAll<HTMLElement>('[data-token]'))
       .filter((el) => {
         const list = el.dataset.token?.split(/\s+/) ?? [];
-        return list.includes(token);
+        return candidates.some((c) => list.includes(c));
       });
     matches.forEach((el) => el.classList.add(HIGHLIGHT_CLASS));
     lastSelectorRef.current = token;


### PR DESCRIPTION
## Summary

Form-side counterpart to [theflywheel/digit-ui-esbuild#66](https://github.com/theflywheel/digit-ui-esbuild/pull/66) (applyTheme v2 expansion). Replaces the 6-tab × 37-input Theme Config descriptor with **3 tabs × 13 v2 semantic fields**:

| Tab | Fields |
|---|---|
| **Brand & Surface** | brand, brand-on, surface-header, surface-page, selected-bg |
| **Text & Borders** | text-primary, text-secondary, text-disabled, border |
| **Status** | error, success, info, warning |

The runtime PR fans each input out to the 30+ existing CSS variables it really controls (e.g. `brand-on` → primary.dark + primary.accent + link.normal + link.hover + text.heading), so a tenant theme is now captured in 13 hex values. That's what makes "ship to a new client in a day" practical.

## Helper text describes effect, not internals

Each field's `help` describes the visible surface it controls ("Page background behind cards and panels", "Validation errors, destructive actions", etc.) so admins don't need to know token taxonomy. Old descriptor's labels like "DigitV2 / chart-3" or "Primary / accent" required reading the codebase to interpret.

## Live preview still works

- `ThemePreview.tsx`: when reading form state into the flat token map, fan v2 keys into the v1 paths the preview's `data-token` attributes already target (`V2_TO_V1_FALLBACK`). The preview reflects v2 edits faithfully without rewriting every data-token in the mockup tree.
- `hoverContext.ts`: hovering a v2 input lights up every preview element whose `data-token` contains either the v2 path itself OR any of the v1 paths that v2 key fans out to.

## Backward compatibility

Legacy v1 records (the existing `kenya-green` on Nairobi) keep rendering correctly at runtime via `applyTheme`'s unchanged v1 flatten path. They open in this trimmed form with empty v2 inputs — admin can either re-enter the 13 values to migrate, or leave as-is and the live UI keeps working.

**Deliberately did NOT auto-prefill v2 from v1**: that would mutate form state on load, leave records carrying both shapes (bloat), and add a duplicated v1↔v2 map. Clean separation is worth the 2-minute manual re-entry for the one existing tenant.

## Test plan
- [ ] `npx tsc -b --noEmit` shows no new TS errors in `src/admin/schemaDescriptors/theme-config.ts` or `src/admin/themeEditor/*` (verified locally — pre-existing errors elsewhere are unrelated)
- [ ] After both this PR and theflywheel/digit-ui-esbuild#66 merge: open Theme Config → Create. Form shows 13 inputs across 3 tabs. Filling them and saving creates a record that drives the full UI (citizen + employee on a fresh tenant).
- [ ] Open existing `kenya-green` record. Form shows 13 empty inputs. Live UI on naipepea still renders kenya-green correctly (v1 backward compat).
- [ ] Hover a v2 input → preview elements driven by it light up (e.g. hover `brand` → Primary button + active sidebar item highlight).

## Related

- Runtime: [theflywheel/digit-ui-esbuild#66](https://github.com/theflywheel/digit-ui-esbuild/pull/66)
- Audit context: [theflywheel/digit-ui-esbuild#65](https://github.com/theflywheel/digit-ui-esbuild/pull/65) (the rgba-companion fix that was the actual blocker on theming working at all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Theme configuration interface simplified with new semantic color keys for enhanced clarity.
  * Theme preview rendering improved for greater accuracy in color representation.
  * Hover highlighting enhanced to provide better visual feedback during theme customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->