### PR TITLE
fix(departments): unblock CRUD path — schema match, Excel boolean, MDMS sanitize (closes egovernments/CCRS#472)

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.test.ts
+++ b/packages/data-provider/src/providers/dataProvider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, beforeEach, mock } from 'node:test';
 import * as assert from 'node:assert/strict';
 import { DigitApiClient } from '../client/DigitApiClient.js';
 import { createDigitDataProvider } from './dataProvider.js';
@@ -50,5 +50,51 @@ describe('createDigitDataProvider', () => {
       () => dp.create('nonexistent', { data: {} }),
       /Unknown resource/,
     );
+  });
+
+  it('strips id and underscore-prefixed metadata from MDMS update payload', async () => {
+    // The form payload includes the ra-admin id and the
+    // _-prefixed fields normalizeMdmsRecord glued on. MDMS schemas
+    // declare additionalProperties:false, so anything extra makes
+    // _update fail (closes egovernments/CCRS#472).
+    mock.method(client, 'mdmsSearch', async () => [
+      {
+        id: 'abc-id',
+        tenantId: 'pg',
+        schemaCode: 'common-masters.Department',
+        uniqueIdentifier: 'DEPT_1',
+        data: { code: 'DEPT_1', name: 'Old Name', active: true },
+        isActive: true,
+        auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
+      },
+    ]);
+    let captured: Record<string, unknown> | null = null;
+    mock.method(client, 'mdmsUpdate', async (rec: { data: Record<string, unknown> }) => {
+      captured = rec.data;
+      return rec;
+    });
+
+    const dp = createDigitDataProvider(client, 'pg');
+    await dp.update('departments', {
+      id: 'DEPT_1',
+      data: {
+        // Form-style payload react-admin would emit:
+        id: 'DEPT_1',
+        code: 'DEPT_1',
+        name: 'New Name',
+        active: false,
+        _isActive: true,
+        _uniqueIdentifier: 'DEPT_1',
+        _auditDetails: { createdBy: 'x' },
+        _schemaCode: 'common-masters.Department',
+        _mdmsId: 'abc-id',
+      },
+      previousData: {} as never,
+    });
+
+    assert.ok(captured, 'mdmsUpdate should have been called');
+    assert.deepEqual(Object.keys(captured!).sort(), ['active', 'code', 'name']);
+    assert.equal((captured as { name: string }).name, 'New Name');
+    assert.equal((captured as { active: boolean }).active, false);
   });
 });

--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -643,7 +643,21 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
         const records = await client.mdmsSearch(tenantId, config.schema!, { uniqueIdentifiers: [String(params.id)] });
         const existing = records.find((r) => r.isActive);
         if (!existing) throw new Error(`Record not found: ${params.id}`);
-        existing.data = { ...existing.data, ...(params.data as Record<string, unknown>) };
+        // Strip the metadata that normalizeMdmsRecord glued onto the
+        // record for react-admin's benefit (id, _isActive, _mdmsId,
+        // _uniqueIdentifier, _auditDetails, _schemaCode, anything starting
+        // with _). MDMS schemas declare additionalProperties:false, so
+        // any of these fields makes the _update payload fail with
+        // INVALID_REQUEST_ADDITIONALPROPERTIES* (closes
+        // egovernments/CCRS#472 — Department update).
+        const incoming = params.data as Record<string, unknown>;
+        const sanitized: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(incoming)) {
+          if (key === 'id') continue;
+          if (key.startsWith('_')) continue;
+          sanitized[key] = value;
+        }
+        existing.data = { ...existing.data, ...sanitized };
         const updated = await client.mdmsUpdate(existing, true);
         return { data: normalizeMdmsRecord(updated, config) };
       }

--- a/src/resources/departments/DepartmentCreate.tsx
+++ b/src/resources/departments/DepartmentCreate.tsx
@@ -1,12 +1,16 @@
 import { DigitCreate, DigitFormCodeInput, DigitFormInput, v } from '@/admin';
 import { BooleanInput } from '@/admin/widgets';
 
+// Department schema (`common-masters.Department`) declares
+// additionalProperties:false and only allows {code, name, active}. Any
+// extra field — `description` was here historically — makes _create
+// reject with INVALID_REQUEST_ADDITIONALPROPERTIES (egovernments/CCRS#472).
+// Designation, which does carry a `description`, has its own form.
 export function DepartmentCreate() {
   return (
     <DigitCreate title="Create Department" record={{ active: true }}>
       <DigitFormInput source="name" label="Name" validate={v.name} />
       <DigitFormCodeInput source="code" label="Code" deriveFrom="name" validate={v.codeRequired} />
-      <DigitFormInput source="description" label="Description" />
       <BooleanInput source="active" label="Active" />
     </DigitCreate>
   );

--- a/src/resources/departments/DepartmentEdit.tsx
+++ b/src/resources/departments/DepartmentEdit.tsx
@@ -4,11 +4,12 @@ import { DeactivationGuard } from '@/admin/DeactivationGuard';
 import { useShowController } from 'ra-core';
 
 export function DepartmentEdit() {
+  // Department schema only allows {code, name, active} — see
+  // DepartmentCreate for the schema vs UI mismatch we used to ship.
   return (
     <DigitEdit title="Edit Department">
       <DigitFormInput source="code" label="Code" disabled />
       <DigitFormInput source="name" label="Name" validate={v.name} />
-      <DigitFormInput source="description" label="Description" />
       <BooleanInput source="active" label="Active" />
       <DeactivationGuardForDepartment />
     </DigitEdit>

--- a/src/utils/excelParser.test.ts
+++ b/src/utils/excelParser.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import * as XLSX from 'xlsx';
+import { parseDepartmentExcel, parseDesignationExcel, parseComplaintTypeExcel } from './excelParser';
+
+// LibreOffice / Google Sheets convert TRUE / FALSE cells to JS booleans
+// when xlsx parses them. Before the ?? fix the parser used `||` for the
+// fallback chain, so any boolean `false` was treated as falsy and
+// silently flipped to the default `'true'` — every deactivated row in
+// a bulk import came back active (closes egovernments/CCRS#472).
+function makeWorkbook(sheetName: string, rows: Record<string, unknown>[]): XLSX.WorkBook {
+  const wb = XLSX.utils.book_new();
+  const ws = XLSX.utils.json_to_sheet(rows);
+  XLSX.utils.book_append_sheet(wb, ws, sheetName);
+  return wb;
+}
+
+describe('Excel boolean coalescing (active column)', () => {
+  it('Department: native JS false stays false', () => {
+    const wb = makeWorkbook('Department', [
+      { code: 'DEPT_A', name: 'Active One', active: true },
+      { code: 'DEPT_B', name: 'Inactive One', active: false },
+    ]);
+    const { data, validation } = parseDepartmentExcel(wb);
+    expect(validation.errors).toEqual([]);
+    expect(data).toEqual([
+      { code: 'DEPT_A', name: 'Active One', active: true },
+      { code: 'DEPT_B', name: 'Inactive One', active: false },
+    ]);
+  });
+
+  it('Department: missing active column defaults to true', () => {
+    const wb = makeWorkbook('Department', [{ code: 'DEPT_A', name: 'Default Active' }]);
+    const { data } = parseDepartmentExcel(wb);
+    expect(data[0]?.active).toBe(true);
+  });
+
+  it('Department: stringified false (with single quote / TRUE / FALSE) parses correctly', () => {
+    const wb = makeWorkbook('Department', [
+      { code: 'DEPT_A', name: 'Quoted False', active: 'false' },
+      { code: 'DEPT_B', name: 'Upper FALSE', active: 'FALSE' },
+      { code: 'DEPT_C', name: 'Upper TRUE', active: 'TRUE' },
+    ]);
+    const { data } = parseDepartmentExcel(wb);
+    expect(data.map((r) => r.active)).toEqual([false, false, true]);
+  });
+
+  it('Designation: boolean false survives coalescing', () => {
+    const wb = makeWorkbook('Designation', [
+      { code: 'DSG_A', name: 'Officer', description: 'desc', department: 'DEPT_1', active: false },
+    ]);
+    const { data } = parseDesignationExcel(wb);
+    expect(data[0]?.active).toBe(false);
+  });
+
+  it('ComplaintType: boolean false survives coalescing', () => {
+    const wb = makeWorkbook('ComplaintType', [
+      { serviceCode: 'POTHOLE', name: 'Pothole', department: 'DEPT_1', slaHours: 24, active: false },
+    ]);
+    const { data } = parseComplaintTypeExcel(wb);
+    expect(data[0]?.active).toBe(false);
+  });
+});

--- a/src/utils/excelParser.ts
+++ b/src/utils/excelParser.ts
@@ -437,7 +437,13 @@ export function parseDepartmentExcel(workbook: XLSX.WorkBook): {
   jsonData.forEach((row, index) => {
     const code = String(row['code'] || row['Code'] || row['departmentCode'] || '').trim();
     const name = String(row['name'] || row['Name'] || row['departmentName'] || '').trim();
-    const activeStr = String(row['active'] || row['Active'] || row['isActive'] || 'true').trim().toLowerCase();
+    // Use ?? not || — when LibreOffice / Google Sheets renders a `FALSE`
+    // cell as the JS boolean `false`, `||` treats it as falsy and falls
+    // through to the default `'true'`, flipping every deactivated row to
+    // active. ?? only short-circuits on null/undefined (closes
+    // egovernments/CCRS#472 — bulk-import boolean parsing).
+    const rawActive = row['active'] ?? row['Active'] ?? row['isActive'] ?? 'true';
+    const activeStr = String(rawActive).trim().toLowerCase();
     const active = activeStr === 'true' || activeStr === 'yes' || activeStr === '1';
 
     if (!code) {
@@ -512,7 +518,9 @@ export function parseDesignationExcel(workbook: XLSX.WorkBook): {
     const description = String(row['description'] || row['Description'] || '').trim() || name;
     const deptRaw = String(row['department'] || row['Department'] || '').trim();
     const department = deptRaw ? deptRaw.split(',').map(s => s.trim()).filter(Boolean) : undefined;
-    const activeStr = String(row['active'] || row['Active'] || row['isActive'] || 'true').trim().toLowerCase();
+    // Use ?? — see Department parser note for the FALSE-coalescing bug.
+    const rawActive = row['active'] ?? row['Active'] ?? row['isActive'] ?? 'true';
+    const activeStr = String(rawActive).trim().toLowerCase();
     const active = activeStr === 'true' || activeStr === 'yes' || activeStr === '1';
 
     if (!code) {
@@ -588,7 +596,9 @@ export function parseComplaintTypeExcel(workbook: XLSX.WorkBook): {
     const keywords = keywordsRaw || name.toLowerCase().replace(/\s+/g, ',');
     const department = String(row['department'] || row['Department'] || '').trim();
     const slaHours = parseInt(String(row['slaHours'] || row['SlaHours'] || row['sla'] || '24'), 10) || 24;
-    const activeStr = String(row['active'] || row['Active'] || row['isActive'] || 'true').trim().toLowerCase();
+    // Use ?? — see Department parser note for the FALSE-coalescing bug.
+    const rawActive = row['active'] ?? row['Active'] ?? row['isActive'] ?? 'true';
+    const activeStr = String(rawActive).trim().toLowerCase();
     const active = activeStr === 'true' || activeStr === 'yes' || activeStr === '1';
 
     if (!serviceCode) {


### PR DESCRIPTION
## Issue

\`egovernments/Citizen-Complaint-Resolution-System#472\` — three sub-bugs on the Department configurator surface, all blockers for go-live.

## Fixes

### 1. UI Create rejected \`description\`

The \`common-masters.Department\` MDMS schema declares \`additionalProperties: false\` and only allows \`{code, name, active}\`. The \`description\` field on the form was a leftover (Designation has it; Department doesn't).

\`\`\`
INVALID_REQUEST: extraneous key [description] is not permitted
\`\`\`

Removed \`description\` from \`DepartmentCreate\` and \`DepartmentEdit\`. Designation's form is unaffected (its schema requires \`description\`).

### 2. UI Update leaked MDMS metadata

\`\`\`
extraneous key [_isActive] is not permitted
extraneous key [_uniqueIdentifier] is not permitted
extraneous key [id] is not permitted
extraneous key [_schemaCode] is not permitted
extraneous key [_auditDetails] is not permitted
extraneous key [_mdmsId] is not permitted
\`\`\`

\`dataProvider.update\` for \`mdms\` resources was spreading \`params.data\` straight onto \`existing.data\`, but \`normalizeMdmsRecord\` glues the react-admin \`id\` and a set of \`_\`-prefixed metadata onto every record so the framework can surface them. Added a strip step (drop \`id\`, drop anything starting with \`_\`) before the spread.

Unit test added: \`strips id and underscore-prefixed metadata from MDMS update payload\`. Asserts only \`code\` / \`name\` / \`active\` reach \`mdmsUpdate\`.

### 3. Bulk Excel import flipped every \`FALSE\` row to active

LibreOffice and Google Sheets render \`TRUE\` / \`FALSE\` cells as JS booleans. The parser fallback chain used \`||\`:

\`\`\`ts
const activeStr = String(row['active'] || row['Active'] || ... || 'true').trim().toLowerCase();
\`\`\`

\`false || 'true'\` is \`'true'\` — every deactivated row got flipped back to active. Required the user-facing workaround in the issue (prepend single-quote to coerce string).

Switched to \`??\` so only \`null\` / \`undefined\` coalesce. Same bug fixed on Designation and ComplaintType parsers. Five-case parser test added covering JS booleans, missing column, uppercased \`TRUE\`/\`FALSE\`, and string-quoted variants.

## Verification on naipepea

SPA built and rsynced to \`/var/www/configurator/\` (bundle \`index-BCXb6lns.js\`, backup at \`/var/www/configurator.bak-20260428-221128\`). API paths exercised via curl:

| Scenario | Result |
|---|---|
| Create with \`description\` | Fails (matches issue) |
| Create without \`description\` | Succeeds |
| Update with leaked \`id\`/\`_isActive\`/\`_uniqueIdentifier\` | Fails (matches issue) |
| Update sanitized | Succeeds |

## Out of scope

- \"Row missing active column doesn't show in list without manual refresh\" — list-cache invalidation in the bulk panel. Flagging as follow-up.
- Adding \`description\` to the Department MDMS schema is a tenant data decision, not a code change.

## Test plan

- [x] \`npm test\` in \`packages/data-provider\` — new sanitize test passes.
- [x] \`npx vitest run src/utils/excelParser.test.ts\` — five parser cases pass.
- [ ] \`/manage/departments/create\` — submit succeeds without the \`description\` field.
- [ ] \`/manage/departments/{code}\` — edit + save succeeds.
- [ ] Bulk import an Excel with \`active=FALSE\` (no quote) — row imports as inactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Excel parser to correctly preserve boolean `false` values in the active column during import.
  * Removed unsupported `description` field from department create and edit forms to align with backend schema requirements.
  * Cleaned up metadata from data updates sent to the backend.

* **Tests**
  * Added test coverage for Excel parsing of boolean values across department, designation, and complaint type imports.
  * Added test verification for data update payload sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->