### PR TITLE
fix(configurator): MDMS create sanitize + bulk-import cache bust + 0,0 coords (#472 follow-up)

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.test.ts
+++ b/packages/data-provider/src/providers/dataProvider.test.ts
@@ -52,6 +52,42 @@ describe('createDigitDataProvider', () => {
     );
   });
 
+  it('strips id and underscore-prefixed metadata from MDMS create payload', async () => {
+    // Same family as the update sanitize fix from PR #40 — a default-
+    // record that includes `id` (some forms set id == code on create)
+    // or any normalised `_*` field would otherwise pass through
+    // mdmsCreate and get rejected by additionalProperties:false.
+    let captured: Record<string, unknown> | null = null;
+    mock.method(client, 'mdmsCreate', async (_t: string, _s: string, _u: string, data: Record<string, unknown>) => {
+      captured = data;
+      return {
+        id: 'new-id',
+        tenantId: 'pg',
+        schemaCode: 'common-masters.Department',
+        uniqueIdentifier: 'DEPT_X',
+        data,
+        isActive: true,
+        auditDetails: { createdBy: 'x', lastModifiedBy: 'x', createdTime: 1, lastModifiedTime: 1 },
+      };
+    });
+
+    const dp = createDigitDataProvider(client, 'pg');
+    await dp.create('departments', {
+      data: {
+        id: 'DEPT_X',
+        code: 'DEPT_X',
+        name: 'pw create',
+        active: true,
+        _isActive: true,
+        _uniqueIdentifier: 'DEPT_X',
+        _mdmsId: 'should-be-stripped',
+      },
+    });
+
+    assert.ok(captured, 'mdmsCreate should have been called');
+    assert.deepEqual(Object.keys(captured!).sort(), ['active', 'code', 'name']);
+  });
+
   it('strips id and underscore-prefixed metadata from MDMS update payload', async () => {
     // The form payload includes the ra-admin id and the
     // _-prefixed fields normalizeMdmsRecord glued on. MDMS schemas

--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -529,8 +529,19 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
     async create(resource, params): Promise<CreateResult> {
       const config = resolveConfig(resource);
       if (config.type === 'mdms') {
-        const data = params.data as Record<string, unknown>;
-        const uid = String(data[config.idField] || data.code || '');
+        const incoming = params.data as Record<string, unknown>;
+        // Same metadata-strip the update path applies (PR #40). The
+        // create path didn't have it, so any defaultRecord that included
+        // `id` (some forms set id == code on create) or any normalised
+        // `_*` field would pass straight through to mdmsCreate and
+        // get rejected by additionalProperties:false schemas.
+        const data: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(incoming)) {
+          if (key === 'id') continue;
+          if (key.startsWith('_')) continue;
+          data[key] = value;
+        }
+        const uid = String(incoming[config.idField] || data.code || '');
         const record = await client.mdmsCreate(tenantId, config.schema!, uid, data);
         return { data: normalizeMdmsRecord(record, config) };
       }

--- a/src/admin/bulk/BulkImportPanel.tsx
+++ b/src/admin/bulk/BulkImportPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   ArrowLeft,
   Download,
@@ -92,6 +93,7 @@ export function BulkImportPanel<Row extends BulkRow>({
   completionExtras,
 }: BulkImportPanelProps<Row>) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [step, setStep] = useState<Step>('landing');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -172,8 +174,15 @@ export function BulkImportPanel<Row extends BulkRow>({
       }
       setProgress(Math.round(((i + 1) / valid.length) * 100));
     }
+    // Bust react-query cache so the list view we navigate back to
+    // shows the fresh count, not the pre-import snapshot. Previously
+    // the operator had to manually refresh — the bug Gurjeet flagged
+    // on egovernments/CCRS#472. invalidateQueries() with no key
+    // invalidates everything, which is overkill but safe (the SPA's
+    // remaining queries are cheap to refetch).
+    await queryClient.invalidateQueries();
     setStep('complete');
-  }, [rows, createOne, columns]);
+  }, [rows, createOne, columns, queryClient]);
 
   const validCount = rows.filter((r) => r.status === 'valid').length;
   const errorCount = rows.length - validCount;

--- a/src/utils/excelParser.test.ts
+++ b/src/utils/excelParser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import * as XLSX from 'xlsx';
-import { parseDepartmentExcel, parseDesignationExcel, parseComplaintTypeExcel } from './excelParser';
+import { parseDepartmentExcel, parseDesignationExcel, parseComplaintTypeExcel, parseBoundaryExcel } from './excelParser';
 
 // LibreOffice / Google Sheets convert TRUE / FALSE cells to JS booleans
 // when xlsx parses them. Before the ?? fix the parser used `||` for the
@@ -58,5 +58,25 @@ describe('Excel boolean coalescing (active column)', () => {
     ]);
     const { data } = parseComplaintTypeExcel(wb);
     expect(data[0]?.active).toBe(false);
+  });
+});
+
+describe('Boundary coordinate parsing', () => {
+  it('keeps 0.0 latitude / longitude as 0 (not undefined)', () => {
+    // `parseFloat(...) || undefined` would coerce a legitimate 0 to
+    // undefined — the Equator + Greenwich Meridian edge. Use NaN-check.
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.json_to_sheet([
+      { code: 'EQ_GP', name: 'Equator + Greenwich', boundaryType: 'Ward', latitude: 0, longitude: 0 },
+      { code: 'NA', name: 'No coords', boundaryType: 'Ward' },
+    ]);
+    XLSX.utils.book_append_sheet(wb, ws, 'Boundary');
+    const { data } = parseBoundaryExcel(wb);
+    const eq = data.find((r) => r.code === 'EQ_GP');
+    const na = data.find((r) => r.code === 'NA');
+    expect(eq?.latitude).toBe(0);
+    expect(eq?.longitude).toBe(0);
+    expect(na?.latitude).toBeUndefined();
+    expect(na?.longitude).toBeUndefined();
   });
 });

--- a/src/utils/excelParser.ts
+++ b/src/utils/excelParser.ts
@@ -179,11 +179,15 @@ export function parseTenantExcel(workbook: XLSX.WorkBook): {
     'logoPath', 'LogoPath', 'Logo Path', 'Logo File Path*', 'Logo File Path'
   );
 
-  // Parse coordinates
+  // Parse coordinates. `parseFloat(...) || undefined` coerces a legit
+  // 0 (Greenwich Meridian / Equator) to undefined — use NaN-check
+  // instead so 0.0 round-trips.
   const latitudeStr = getValue(row, 'latitude', 'Latitude');
   const longitudeStr = getValue(row, 'longitude', 'Longitude');
-  const latitude = latitudeStr ? parseFloat(latitudeStr) || undefined : undefined;
-  const longitude = longitudeStr ? parseFloat(longitudeStr) || undefined : undefined;
+  const latNum = latitudeStr ? parseFloat(latitudeStr) : NaN;
+  const lngNum = longitudeStr ? parseFloat(longitudeStr) : NaN;
+  const latitude = Number.isFinite(latNum) ? latNum : undefined;
+  const longitude = Number.isFinite(lngNum) ? lngNum : undefined;
 
   // Validate required fields
   if (!tenantCode) {
@@ -340,9 +344,13 @@ export function parseBoundaryExcel(workbook: XLSX.WorkBook): {
     const boundaryType = String(row['boundaryType'] || row['BoundaryType'] || row['type'] || '').trim();
     const parentCode = String(row['parentCode'] || row['ParentCode'] || row['parent'] || '').trim() || undefined;
 
-    // Parse coordinates
-    const latitude = parseFloat(String(row['latitude'] || row['Latitude'] || '0')) || undefined;
-    const longitude = parseFloat(String(row['longitude'] || row['Longitude'] || '0')) || undefined;
+    // Parse coordinates — keep 0.0 as a legit value (Equator / Greenwich).
+    const latRaw = row['latitude'] ?? row['Latitude'];
+    const lngRaw = row['longitude'] ?? row['Longitude'];
+    const latNum = latRaw == null || latRaw === '' ? NaN : parseFloat(String(latRaw));
+    const lngNum = lngRaw == null || lngRaw === '' ? NaN : parseFloat(String(lngRaw));
+    const latitude = Number.isFinite(latNum) ? latNum : undefined;
+    const longitude = Number.isFinite(lngNum) ? lngNum : undefined;
 
     if (!code) {
       errors.push({


### PR DESCRIPTION
Three follow-ups to PR #40 from the explorer review.

### 1. `dataProvider.create()` lacks the same `_*` / `id` strip the update path ships
Same family as the Department `description` bug PR #40 fixed. Any defaultRecord that includes `id` or normalised `_*` fields would otherwise pass straight through `mdmsCreate` and get rejected by `additionalProperties:false` schemas. Added the same sanitize. Unit test mirrors the existing update-path test.

### 2. BulkImportPanel left react-query stale after import
Operators saw pre-import counts on the list view and had to manually refresh — exact symptom Gurjeet flagged on egovernments/CCRS#472. `queryClient.invalidateQueries()` after the create-loop finishes.

### 3. `parseFloat(coord) || undefined` coerced legit `0.0` to undefined
Equator + Greenwich Meridian edge — Kenya sits a couple of degrees off the Equator and a 0,0 boundary import would silently lose its coordinates. Same on the tenant parser. Switched to `Number.isFinite` check. Vitest covers the edge.

## Verification
- New unit tests green (`mdmsCreate` sanitize + `parseBoundaryExcel` 0,0 round-trip).
- Configurator rebuilt and deployed to naipepea (`/var/www/configurator/`, prior bundle backed up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coordinate parsing to correctly handle zero latitude/longitude values during Excel imports.
  * Bulk import operations now refresh data cache after processing to display updated results immediately.
  * Data creation now properly filters out metadata fields to prevent invalid payloads.

* **Tests**
  * Added tests for payload sanitization and boundary coordinate parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->