### PR TITLE
feat(theme): trim form to v3 designer-1:1 (~70 inputs, 9 tabs)

### DIFF
--- a/src/admin/schemaDescriptors/theme-config.ts
+++ b/src/admin/schemaDescriptors/theme-config.ts
@@ -1,87 +1,309 @@
 import type { SchemaDescriptor } from './types';
 
 /**
- * Descriptor for `common-masters.ThemeConfig` — v2 semantic shape.
+ * Descriptor for `common-masters.ThemeConfig` — v3 designer-1:1 shape.
  *
- * The runtime applyTheme.js (theflywheel/digit-ui-esbuild#66) expands these
- * 13 flat semantic keys into the 30+ CSS variables the existing CSS consumes,
- * so a tenant theme is now captured in roughly a dozen inputs instead of 35+.
- * That is what makes the "ship to a new client in a day" onboarding goal
- * practical.
+ * Mirrors the "Theme System" spreadsheet's New System / Nairobi Theme tabs
+ * 1:1: every role the designer exposes is its own form input. The runtime
+ * counterpart (theflywheel/digit-ui-esbuild applyTheme.js V3_EXPANSION)
+ * fans each input out to the CSS vars that actually render it — both
+ * existing legacy vars where a role already had one, and the new
+ * `--color-<role>` vars introduced for granular roles (button hover,
+ * input focus, sidebar selected, status text/border/bg, table hover/
+ * selected, etc.).
  *
- * Old v1 records (nested groups like `colors.primary.main`) continue to
- * render correctly at runtime via the legacy v1 flatten path — they just
- * aren't editable through this trimmed form. Either re-enter the values as
- * v2 to migrate, or edit the raw JSON via MDMS API.
+ * Legacy v1 records continue to render correctly via the unchanged Pass 1
+ * flatten. v2 records via Pass 2 SEMANTIC_EXPANSION. This descriptor only
+ * shapes the form; existing records can be re-saved through it to migrate
+ * to v3.
  *
- * Each input fans out to the CSS vars listed beside it; the help text
- * describes the surface effect, not the var names, so admins don't need to
- * know the underlying token taxonomy.
+ * Helper text describes the *visible surface* each token controls so an
+ * admin doesn't need the underlying CSS-var taxonomy.
  */
 export const themeConfigDescriptor: SchemaDescriptor = {
   schema: 'common-masters.ThemeConfig',
   customEditor: 'theme-config',
   groups: [
     { title: 'Identity', fields: ['code', 'name', 'version'] },
+
     { title: 'Brand & Surface', fields: [
-      'colors.brand',
-      'colors.brand-on',
-      'colors.surface-header',
-      'colors.surface-page',
-      'colors.selected-bg',
+      'colors.primary-1',
+      'colors.primary-2',
+      'colors.primary-1-bg',
+      'colors.primary-2-bg',
+      'colors.page-bg',
+      'colors.page-secondary-bg',
+      'colors.card-border',
+      'colors.card-divider',
     ] },
-    { title: 'Text & Borders', fields: [
+
+    { title: 'Text', fields: [
+      'colors.text-heading',
       'colors.text-primary',
       'colors.text-secondary',
       'colors.text-disabled',
-      'colors.border',
     ] },
+
+    { title: 'Buttons', fields: [
+      'colors.button-primary-bg-default',
+      'colors.button-primary-bg-hover',
+      'colors.button-primary-bg-pressed',
+      'colors.button-primary-text',
+      'colors.button-primary-border',
+      'colors.button-primary-disabled-bg',
+      'colors.button-primary-disabled-text',
+      'colors.button-secondary-bg-default',
+      'colors.button-secondary-bg-hover',
+      'colors.button-secondary-bg-pressed',
+      'colors.button-secondary-text',
+      'colors.button-secondary-border',
+      'colors.button-tertiary-text',
+    ] },
+
+    { title: 'Inputs', fields: [
+      'colors.input-bg',
+      'colors.input-border-default',
+      'colors.input-border-focus',
+      'colors.input-border-error',
+      'colors.input-placeholder',
+      'colors.input-text',
+      'colors.input-label',
+      'colors.input-helper',
+    ] },
+
+    { title: 'Header & Sidebar', fields: [
+      'colors.header-bg',
+      'colors.header-text',
+      'colors.header-icon',
+      'colors.sidebar-bg',
+      'colors.sidebar-text-active',
+      'colors.sidebar-text-default',
+      'colors.sidebar-hover-text',
+      'colors.sidebar-hover-bg',
+      'colors.sidebar-icon-active',
+      'colors.sidebar-selected-bg',
+      'colors.sidebar-selected-text',
+    ] },
+
     { title: 'Status', fields: [
-      'colors.error',
-      'colors.success',
-      'colors.info',
-      'colors.warning',
+      'colors.status-success-text',
+      'colors.status-success-bg',
+      'colors.status-success-border',
+      'colors.status-error-text',
+      'colors.status-error-bg',
+      'colors.status-error-border',
+      'colors.status-warning-text',
+      'colors.status-warning-bg',
+      'colors.status-warning-border',
+      'colors.status-info-text',
+      'colors.status-info-bg',
+      'colors.status-info-border',
+      'colors.card-success',
+      'colors.card-error',
+    ] },
+
+    { title: 'Tables & Misc', fields: [
+      'colors.table-header-bg',
+      'colors.table-header-text',
+      'colors.table-row-bg',
+      'colors.table-alt-row',
+      'colors.table-row-text',
+      'colors.table-border',
+      'colors.table-hover',
+      'colors.table-selected',
+      'colors.table-hover-text',
+      'colors.table-selected-text',
+      'colors.loader',
+      'colors.progress',
+      'colors.tooltip-bg',
+      'colors.tooltip-text',
+    ] },
+
+    { title: 'Charts', fields: [
+      'colors.chart-1',
+      'colors.chart-2',
+      'colors.chart-3',
+      'colors.chart-4',
+      'colors.chart-5',
     ] },
   ],
   fields: [
-    // --- Identity ---
+    // ── Identity ────────────────────────────────────────────────────────────
     { path: 'code', widget: 'text', required: true,
       help: 'Unique theme identifier, e.g. "kenya-green". Used as the MDMS record key.' },
     { path: 'name', widget: 'text',
       help: 'Human-readable theme name shown in admin UIs.' },
     { path: 'version', widget: 'text',
-      help: 'Schema version — set to "2" for new themes (semantic shape).' },
+      help: 'Schema version — set to "3" for new themes following the designer 1:1 spec.' },
 
-    // --- Brand & Surface ---
-    { path: 'colors.brand', widget: 'color', label: 'Brand',
-      help: 'The primary brand color — buttons, highlights, active nav, focus rings. The most prominent color in the UI.' },
-    { path: 'colors.brand-on', widget: 'color', label: 'Brand-on',
-      help: 'The accent paired with brand — links, headings, button hover/pressed states. Usually a contrasting hue (e.g. dark green when brand is amber).' },
-    { path: 'colors.surface-header', widget: 'color', label: 'Surface / header',
-      help: 'Background of the top header bar and side navigation rail.' },
-    { path: 'colors.surface-page', widget: 'color', label: 'Surface / page',
-      help: 'Page background behind cards and panels. Usually a near-white grey.' },
-    { path: 'colors.selected-bg', widget: 'color', label: 'Selected-bg',
-      help: 'Soft tint for selected rows, active menu items, picked dropdown options. Typically a light wash of brand.' },
+    // ── Brand & Surface ─────────────────────────────────────────────────────
+    { path: 'colors.primary-1', widget: 'color', label: 'Primary 1',
+      help: 'Dominant brand color — header/sidebar background, headings, anchor links, button-primary text-on-fill, focused input ring. Often the more saturated of the two brand colors (e.g. dark green on Nairobi).' },
+    { path: 'colors.primary-2', widget: 'color', label: 'Primary 2',
+      help: 'Accent brand color — primary button background, focus highlights, active sidebar pill. Pairs with Primary 1 (e.g. amber on Nairobi).' },
+    { path: 'colors.primary-1-bg', widget: 'color', label: 'Primary 1 bg',
+      help: 'Soft tint of Primary 1 — used as table-row hover/selected, sidebar hover background, selection highlights.' },
+    { path: 'colors.primary-2-bg', widget: 'color', label: 'Primary 2 bg',
+      help: 'Soft tint of Primary 2 — alternate selection wash.' },
+    { path: 'colors.page-bg', widget: 'color', label: 'Page background',
+      help: 'Main app background (paper white). Cards, secondary-button background, table rows sit on this.' },
+    { path: 'colors.page-secondary-bg', widget: 'color', label: 'Page secondary background',
+      help: 'Subtle off-white for zebra rows, alternate panel surfaces, disabled-input fill.' },
+    { path: 'colors.card-border', widget: 'color', label: 'Card border',
+      help: 'Hairline around cards, panels, popovers.' },
+    { path: 'colors.card-divider', widget: 'color', label: 'Card divider',
+      help: 'Inner dividers within cards / sections.' },
 
-    // --- Text & Borders ---
+    // ── Text ────────────────────────────────────────────────────────────────
+    { path: 'colors.text-heading', widget: 'color', label: 'Text / heading',
+      help: 'h1–h6 headings, card titles, section headers — strong visual hierarchy.' },
     { path: 'colors.text-primary', widget: 'color', label: 'Text / primary',
       help: 'Default body text — paragraphs, table cells, form values.' },
     { path: 'colors.text-secondary', widget: 'color', label: 'Text / secondary',
-      help: 'De-emphasized text — captions, metadata, helper text, placeholders.' },
+      help: 'Supporting text — captions, metadata, subtitles.' },
     { path: 'colors.text-disabled', widget: 'color', label: 'Text / disabled',
-      help: 'Text and icon color for disabled buttons, inputs, and menu items.' },
-    { path: 'colors.border', widget: 'color', label: 'Border',
-      help: 'Hairlines: card borders, table dividers, input borders, divider lines.' },
+      help: 'Inactive text — disabled buttons/inputs, disabled menu items.' },
 
-    // --- Status ---
-    { path: 'colors.error', widget: 'color', label: 'Error',
-      help: 'Validation errors, destructive actions, error toasts and badges.' },
-    { path: 'colors.success', widget: 'color', label: 'Success',
-      help: 'Successful state — checkmarks, success toasts, confirmation badges.' },
-    { path: 'colors.info', widget: 'color', label: 'Info',
-      help: 'Informational alerts and badges — neutral attention.' },
-    { path: 'colors.warning', widget: 'color', label: 'Warning',
-      help: 'Warning alerts and badges — caution but not destructive.' },
+    // ── Buttons (Primary 7 + Secondary 5 + Tertiary 1 = 13) ────────────────
+    { path: 'colors.button-primary-bg-default', widget: 'color', label: 'Primary button / bg default',
+      help: 'Resting background of the primary call-to-action button.' },
+    { path: 'colors.button-primary-bg-hover', widget: 'color', label: 'Primary button / bg hover',
+      help: 'Background when the cursor is over a primary button. Typically a darker shade of bg-default.' },
+    { path: 'colors.button-primary-bg-pressed', widget: 'color', label: 'Primary button / bg pressed',
+      help: 'Background during the brief active/clicked moment. Even darker than hover.' },
+    { path: 'colors.button-primary-text', widget: 'color', label: 'Primary button / text',
+      help: 'Text color inside the primary button. Must read against bg-default.' },
+    { path: 'colors.button-primary-border', widget: 'color', label: 'Primary button / border',
+      help: 'Optional border around the primary button. Often the same as bg-default.' },
+    { path: 'colors.button-primary-disabled-bg', widget: 'color', label: 'Primary button / disabled bg',
+      help: 'Background when the primary button is inactive.' },
+    { path: 'colors.button-primary-disabled-text', widget: 'color', label: 'Primary button / disabled text',
+      help: 'Text color when the primary button is inactive.' },
+    { path: 'colors.button-secondary-bg-default', widget: 'color', label: 'Secondary button / bg default',
+      help: 'Resting background of the secondary (outlined) button. Usually paper white.' },
+    { path: 'colors.button-secondary-bg-hover', widget: 'color', label: 'Secondary button / bg hover',
+      help: 'Background when hovering the secondary button.' },
+    { path: 'colors.button-secondary-bg-pressed', widget: 'color', label: 'Secondary button / bg pressed',
+      help: 'Background during the active/clicked moment of the secondary button.' },
+    { path: 'colors.button-secondary-text', widget: 'color', label: 'Secondary button / text',
+      help: 'Text color inside the secondary button. Usually Primary 1.' },
+    { path: 'colors.button-secondary-border', widget: 'color', label: 'Secondary button / border',
+      help: 'Border defining the secondary button outline.' },
+    { path: 'colors.button-tertiary-text', widget: 'color', label: 'Tertiary / link text',
+      help: 'Text-only buttons and links — the most subtle action treatment. Usually Primary 1.' },
+
+    // ── Inputs (8) ──────────────────────────────────────────────────────────
+    { path: 'colors.input-bg', widget: 'color', label: 'Input / bg',
+      help: 'Background of form input fields, textareas, selects.' },
+    { path: 'colors.input-border-default', widget: 'color', label: 'Input / border default',
+      help: 'Resting border color of inputs (unfocused, no error).' },
+    { path: 'colors.input-border-focus', widget: 'color', label: 'Input / border focus',
+      help: 'Border color when an input has keyboard focus. Usually Primary 1 — the brand-aware focus ring.' },
+    { path: 'colors.input-border-error', widget: 'color', label: 'Input / border error',
+      help: 'Border color when validation fails on an input.' },
+    { path: 'colors.input-placeholder', widget: 'color', label: 'Input / placeholder',
+      help: 'Placeholder text inside empty inputs.' },
+    { path: 'colors.input-text', widget: 'color', label: 'Input / text',
+      help: 'Color of user-entered text inside inputs.' },
+    { path: 'colors.input-label', widget: 'color', label: 'Input / label',
+      help: 'Label text above or beside inputs.' },
+    { path: 'colors.input-helper', widget: 'color', label: 'Input / helper',
+      help: 'Helper or hint text below inputs.' },
+
+    // ── Header & Sidebar (3 + 8 = 11) ───────────────────────────────────────
+    { path: 'colors.header-bg', widget: 'color', label: 'Header / bg',
+      help: 'Background of the top navigation bar.' },
+    { path: 'colors.header-text', widget: 'color', label: 'Header / text',
+      help: 'Text color on the header (titles, actions).' },
+    { path: 'colors.header-icon', widget: 'color', label: 'Header / icon',
+      help: 'Icon and logo color in the header.' },
+    { path: 'colors.sidebar-bg', widget: 'color', label: 'Sidebar / bg',
+      help: 'Background of the side navigation rail.' },
+    { path: 'colors.sidebar-text-active', widget: 'color', label: 'Sidebar / text active',
+      help: 'Text color of the actively-selected navigation item.' },
+    { path: 'colors.sidebar-text-default', widget: 'color', label: 'Sidebar / text default',
+      help: 'Text color of idle (non-hovered, non-selected) sidebar items.' },
+    { path: 'colors.sidebar-hover-text', widget: 'color', label: 'Sidebar / hover text',
+      help: 'Text color on a sidebar item being hovered.' },
+    { path: 'colors.sidebar-hover-bg', widget: 'color', label: 'Sidebar / hover bg',
+      help: 'Background tint shown when hovering a sidebar item.' },
+    { path: 'colors.sidebar-icon-active', widget: 'color', label: 'Sidebar / icon active',
+      help: 'Icon color on the actively-selected sidebar item.' },
+    { path: 'colors.sidebar-selected-bg', widget: 'color', label: 'Sidebar / selected bg',
+      help: 'Background of the persistent "selected" pill on the active sidebar item.' },
+    { path: 'colors.sidebar-selected-text', widget: 'color', label: 'Sidebar / selected text',
+      help: 'Text color inside the selected pill.' },
+
+    // ── Status (4 severities × 3 roles + 2 cards = 14) ──────────────────────
+    { path: 'colors.status-success-text', widget: 'color', label: 'Status success / text',
+      help: 'Text inside success alerts and badges.' },
+    { path: 'colors.status-success-bg', widget: 'color', label: 'Status success / bg',
+      help: 'Background fill of success alerts and toasts (soft tint).' },
+    { path: 'colors.status-success-border', widget: 'color', label: 'Status success / border',
+      help: 'Left-border / outline accent of success alerts.' },
+    { path: 'colors.status-error-text', widget: 'color', label: 'Status error / text',
+      help: 'Text inside error alerts, validation errors, destructive labels.' },
+    { path: 'colors.status-error-bg', widget: 'color', label: 'Status error / bg',
+      help: 'Background fill of error alerts and toasts.' },
+    { path: 'colors.status-error-border', widget: 'color', label: 'Status error / border',
+      help: 'Left-border / outline accent of error alerts.' },
+    { path: 'colors.status-warning-text', widget: 'color', label: 'Status warning / text',
+      help: 'Text inside warning alerts and badges.' },
+    { path: 'colors.status-warning-bg', widget: 'color', label: 'Status warning / bg',
+      help: 'Background fill of warning alerts.' },
+    { path: 'colors.status-warning-border', widget: 'color', label: 'Status warning / border',
+      help: 'Left-border / outline accent of warning alerts.' },
+    { path: 'colors.status-info-text', widget: 'color', label: 'Status info / text',
+      help: 'Text inside info alerts and neutral-attention badges.' },
+    { path: 'colors.status-info-bg', widget: 'color', label: 'Status info / bg',
+      help: 'Background fill of info alerts.' },
+    { path: 'colors.status-info-border', widget: 'color', label: 'Status info / border',
+      help: 'Left-border / outline accent of info alerts.' },
+    { path: 'colors.card-success', widget: 'color', label: 'Card / success accent',
+      help: 'Accent color on success-state cards (e.g. successfully-resolved complaint card).' },
+    { path: 'colors.card-error', widget: 'color', label: 'Card / error accent',
+      help: 'Accent color on error-state cards.' },
+
+    // ── Tables & Misc (10 + 4 = 14) ─────────────────────────────────────────
+    { path: 'colors.table-header-bg', widget: 'color', label: 'Table / header bg',
+      help: 'Background of the table header row.' },
+    { path: 'colors.table-header-text', widget: 'color', label: 'Table / header text',
+      help: 'Text color in the table header (column titles).' },
+    { path: 'colors.table-row-bg', widget: 'color', label: 'Table / row bg',
+      help: 'Default body-row background.' },
+    { path: 'colors.table-alt-row', widget: 'color', label: 'Table / alt row',
+      help: 'Alternate body-row background for zebra striping.' },
+    { path: 'colors.table-row-text', widget: 'color', label: 'Table / row text',
+      help: 'Text color inside body cells.' },
+    { path: 'colors.table-border', widget: 'color', label: 'Table / border',
+      help: 'Grid lines between rows / columns.' },
+    { path: 'colors.table-hover', widget: 'color', label: 'Table / hover',
+      help: 'Background tint when hovering a row.' },
+    { path: 'colors.table-selected', widget: 'color', label: 'Table / selected',
+      help: 'Background tint of a selected row.' },
+    { path: 'colors.table-hover-text', widget: 'color', label: 'Table / hover text',
+      help: 'Text color on a hovered row (only meaningful if the hover-bg is dark).' },
+    { path: 'colors.table-selected-text', widget: 'color', label: 'Table / selected text',
+      help: 'Text color inside the selected row.' },
+    { path: 'colors.loader', widget: 'color', label: 'Loader',
+      help: 'Color of the loading spinner / progress indicator.' },
+    { path: 'colors.progress', widget: 'color', label: 'Progress',
+      help: 'Progress-bar fill color.' },
+    { path: 'colors.tooltip-bg', widget: 'color', label: 'Tooltip / bg',
+      help: 'Background color of tooltips.' },
+    { path: 'colors.tooltip-text', widget: 'color', label: 'Tooltip / text',
+      help: 'Text color inside tooltips.' },
+
+    // ── Charts (5) ──────────────────────────────────────────────────────────
+    { path: 'colors.chart-1', widget: 'color', label: 'Chart 1',
+      help: 'First data-series color (bar 1, line 1, pie slice 1).' },
+    { path: 'colors.chart-2', widget: 'color', label: 'Chart 2',
+      help: 'Second data-series color.' },
+    { path: 'colors.chart-3', widget: 'color', label: 'Chart 3',
+      help: 'Third data-series color.' },
+    { path: 'colors.chart-4', widget: 'color', label: 'Chart 4',
+      help: 'Fourth data-series color.' },
+    { path: 'colors.chart-5', widget: 'color', label: 'Chart 5',
+      help: 'Fifth data-series color.' },
   ],
 };

--- a/src/admin/themeEditor/ThemePreview.tsx
+++ b/src/admin/themeEditor/ThemePreview.tsx
@@ -19,14 +19,20 @@ function flatten(obj: unknown, prefix = ''): Record<string, string> {
 }
 
 /**
- * Mirror of the runtime SEMANTIC_EXPANSION (theflywheel/digit-ui-esbuild
- * src/theme/applyTheme.js): each v2 input back-fills the legacy v1 paths the
- * preview already targets. The preview was built against v1 paths; rather
- * than rewrite every `data-token` attribute, we project v2 → v1 here so a
- * Brand/Brand-on/Surface-header/etc. value flows into all the v1 paths the
- * preview already reads.
+ * Mirror of the runtime SEMANTIC_EXPANSION + V3_EXPANSION (theflywheel/
+ * digit-ui-esbuild src/theme/applyTheme.js). Each v2/v3 input back-fills the
+ * v1 paths the preview's data-token attributes already target. The preview
+ * was built against v1 paths; rather than rewrite every data-token, we
+ * project v2 and v3 → v1 here so any input shape drives the preview.
+ *
+ * For v3, each section's input maps to the closest v1 path that the preview
+ * already renders. Where the preview doesn't have a dedicated visual for a
+ * granular role (e.g. button-primary-bg-hover, sidebar-selected-text), the
+ * input is omitted from this map and only takes effect on the live UI via
+ * the surgical CSS overrides in overrides.css.
  */
 const V2_TO_V1_FALLBACK: Record<string, string[]> = {
+  // v2
   brand: ['primary.main'],
   'brand-on': ['primary.dark', 'primary.accent', 'link.normal', 'link.hover', 'text.heading'],
   'surface-header': ['secondary', 'digitv2.header-sidenav'],
@@ -40,6 +46,46 @@ const V2_TO_V1_FALLBACK: Record<string, string[]> = {
   info: ['digitv2.alert-info', 'info-dark'],
   warning: ['warning-dark'],
   'selected-bg': ['primary.selected-bg', 'digitv2.primary-bg'],
+  // v3 — main palette
+  'primary-1': ['primary.dark', 'primary.accent', 'link.normal', 'link.hover', 'text.heading', 'secondary', 'digitv2.header-sidenav'],
+  'primary-2': ['primary.main'],
+  'primary-1-bg': ['primary.selected-bg', 'digitv2.primary-bg'],
+  // v3 — text
+  'text-heading': ['text.heading'],
+  // v3 — page
+  'page-bg': ['grey.bg'],
+  'page-secondary-bg': ['grey.light', 'grey.lighter'],
+  // v3 — buttons (preview shows Primary + Secondary buttons)
+  'button-primary-bg-default': ['primary.main'],
+  'button-primary-text': ['primary.dark'],
+  'button-secondary-bg-default': ['grey.bg'],
+  'button-secondary-text': ['primary.dark'],
+  'button-tertiary-text': ['link.normal'],
+  // v3 — inputs (preview has a disabled input)
+  'input-bg': ['grey.bg'],
+  'input-border-default': ['input-border'],
+  'input-text': ['text.primary'],
+  'input-placeholder': ['text.muted'],
+  // v3 — header / sidebar (preview shows both)
+  'header-bg': ['digitv2.header-sidenav'],
+  'header-text': ['secondary'],
+  'sidebar-bg': ['digitv2.header-sidenav'],
+  'sidebar-selected-bg': ['primary.selected-bg'],
+  'sidebar-selected-text': ['primary.main'],
+  // v3 — status (preview shows alerts)
+  'status-success-text': ['success'],
+  'status-success-bg': ['digitv2.alert-success-bg'],
+  'status-error-text': ['error', 'error-dark'],
+  'status-error-bg': ['digitv2.alert-error-bg'],
+  'status-warning-text': ['warning-dark'],
+  'status-info-text': ['info-dark', 'digitv2.alert-info'],
+  'status-info-bg': ['digitv2.alert-info-bg'],
+  // v3 — charts
+  'chart-1': ['digitv2.chart-1'],
+  'chart-2': ['digitv2.chart-2'],
+  'chart-3': ['digitv2.chart-3'],
+  'chart-4': ['digitv2.chart-4'],
+  'chart-5': ['digitv2.chart-5'],
 };
 
 /** Apply v2 → v1 fan-out so the preview reads consistent values whether the

--- a/src/admin/themeEditor/hoverContext.ts
+++ b/src/admin/themeEditor/hoverContext.ts
@@ -17,14 +17,16 @@ export interface HoverContextValue {
 const HIGHLIGHT_CLASS = 'theme-token-hover';
 
 /**
- * v2 semantic key → list of v1 paths it fans out to. Mirrors the
- * SEMANTIC_EXPANSION map in theflywheel/digit-ui-esbuild's applyTheme.js
- * and the V2_TO_V1_FALLBACK map in ThemePreview. Kept here so a hover on a
- * v2 form input lights up every v1 [data-token] element it ultimately drives.
+ * v2/v3 semantic key → list of v1 paths it fans out to. Mirrors the
+ * SEMANTIC_EXPANSION + V3_EXPANSION maps in theflywheel/digit-ui-esbuild's
+ * applyTheme.js and the V2_TO_V1_FALLBACK map in ThemePreview. Kept here
+ * so hovering a form input lights up every v1 [data-token] element it
+ * ultimately drives in the preview.
  *
  * Keys are without the `colors.` prefix; the matcher adds it back.
  */
 const V2_TO_V1: Record<string, string[]> = {
+  // v2
   brand: ['primary.main'],
   'brand-on': ['primary.dark', 'primary.accent', 'link.normal', 'link.hover', 'text.heading'],
   'surface-header': ['secondary', 'digitv2.header-sidenav'],
@@ -38,6 +40,46 @@ const V2_TO_V1: Record<string, string[]> = {
   info: ['digitv2.alert-info', 'info-dark'],
   warning: ['warning-dark'],
   'selected-bg': ['primary.selected-bg', 'digitv2.primary-bg'],
+  // v3 — main palette
+  'primary-1': ['primary.dark', 'primary.accent', 'link.normal', 'link.hover', 'text.heading', 'secondary', 'digitv2.header-sidenav'],
+  'primary-2': ['primary.main'],
+  'primary-1-bg': ['primary.selected-bg', 'digitv2.primary-bg'],
+  // v3 — text
+  'text-heading': ['text.heading'],
+  // v3 — page
+  'page-bg': ['grey.bg'],
+  'page-secondary-bg': ['grey.light', 'grey.lighter'],
+  // v3 — buttons
+  'button-primary-bg-default': ['primary.main'],
+  'button-primary-text': ['primary.dark'],
+  'button-secondary-bg-default': ['grey.bg'],
+  'button-secondary-text': ['primary.dark'],
+  'button-tertiary-text': ['link.normal'],
+  // v3 — inputs
+  'input-bg': ['grey.bg'],
+  'input-border-default': ['input-border'],
+  'input-text': ['text.primary'],
+  'input-placeholder': ['text.muted'],
+  // v3 — header / sidebar
+  'header-bg': ['digitv2.header-sidenav'],
+  'header-text': ['secondary'],
+  'sidebar-bg': ['digitv2.header-sidenav'],
+  'sidebar-selected-bg': ['primary.selected-bg'],
+  'sidebar-selected-text': ['primary.main'],
+  // v3 — status
+  'status-success-text': ['success'],
+  'status-success-bg': ['digitv2.alert-success-bg'],
+  'status-error-text': ['error', 'error-dark'],
+  'status-error-bg': ['digitv2.alert-error-bg'],
+  'status-warning-text': ['warning-dark'],
+  'status-info-text': ['info-dark', 'digitv2.alert-info'],
+  'status-info-bg': ['digitv2.alert-info-bg'],
+  // v3 — charts
+  'chart-1': ['digitv2.chart-1'],
+  'chart-2': ['digitv2.chart-2'],
+  'chart-3': ['digitv2.chart-3'],
+  'chart-4': ['digitv2.chart-4'],
+  'chart-5': ['digitv2.chart-5'],
 };
 
 /** Tokens to look for given a hovered form field path. For a v2 form input


### PR DESCRIPTION
## Summary

Form-side counterpart to [theflywheel/digit-ui-esbuild#73](https://github.com/theflywheel/digit-ui-esbuild/pull/73) (v3 runtime + surgical CSS overrides). Replaces the v2 13-input form with a v3 form that mirrors the designer's "Theme System" spreadsheet (New System / Nairobi Theme tabs) 1:1.

## 9 tabs × ~70 inputs

| Tab | # | Roles |
|---|---|---|
| Identity | 3 | code, name, version |
| **Brand & Surface** | **8** | primary-1, primary-2, primary-1-bg, primary-2-bg, page-bg, page-secondary-bg, card-border, card-divider |
| **Text** | **4** | heading, primary, secondary, disabled |
| **Buttons** | **13** | primary × 7 (default/hover/pressed/text/border/disabled-bg/disabled-text) + secondary × 5 + tertiary × 1 |
| **Inputs** | **8** | bg, border-default/focus/error, placeholder, text, label, helper |
| **Header & Sidebar** | **11** | header × 3 + sidebar × 8 (incl. selected-bg/text, hover-bg/text) |
| **Status** | **14** | 4 severities × {text, bg, border} + 2 cards (success/error) |
| **Tables & Misc** | **14** | table × 10 + loader + progress + tooltip × 2 |
| **Charts** | **5** | chart-1..5 |

Helper text per input describes the *visible surface* the role controls — admin doesn't need the underlying CSS-var taxonomy.

## After this lands

Once both PRs are merged + deployed, opening kenya-green in the form lets admin enter all ~70 designer values from the spreadsheet's Nairobi Theme tab. Save → live UI on naipepea picks up the runtime's V3_EXPANSION and surgical CSS overrides → header dark green, primary buttons amber with explicit hover (#E6B800) and pressed (#CC9F00) states, sidebar selected pill (now via dedicated `--color-sidebar-selected-bg`), input focus rings in primary-1, alert text/border/bg as 3 distinct roles per severity, table hover/selected rows in `primary-1-bg` tint, tooltip in primary-1.

## Backward compatibility

- v1 records (pre-#65/#66 kenya-green): runtime Pass 1 still flattens nested groups; v3 form opens with empty inputs but live UI continues rendering via Pass 1.
- v2 records (post-#66 kenya-green): runtime Pass 2 still active; v3 form shows empty inputs (admin migrates by re-entering); live UI keeps rendering via Pass 2 until the v3 form is filled and saved.
- Deliberately no auto-prefill from v1/v2 — clean separation, no mongrel records.

## Live preview

`ThemePreview.tsx` was built against v1 paths. Rather than rewrite all `data-token` attributes, the V2_TO_V1_FALLBACK map gets v3 entries that project each v3 key onto the v1 path the preview already renders. Where a v3 role has no preview surface (button-primary-bg-hover, sidebar-icon-active, etc.), the input is omitted from the projection — only takes effect on the live UI via overrides.css. The preview's hover-highlight still works via the matching extension in `hoverContext.ts`.

## Test plan
- [x] `npx tsc -b --noEmit` passes for changed files (no new TS errors in theme-config.ts / themeEditor/*)
- [ ] After merge + this and theflywheel/digit-ui-esbuild#73 deploy: open `kenya-green` Edit form. See 9 tabs with ~70 inputs. Tabs match designer's spreadsheet sections.
- [ ] Hover any v3 input → corresponding preview element lights up (where the role has a preview surface)
- [ ] Fill all ~70 inputs from spreadsheet's Nairobi Theme tab. Save. Citizen + employee on naipepea render the designer's full Nairobi spec.

## Related
- Runtime + surgical CSS: theflywheel/digit-ui-esbuild#73
- Preceding work: theflywheel/digit-ui-esbuild#65 (rgba steamroller fix), #66 (v2 expansion), this repo's #39 (v2 form trim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded theme configuration with enhanced token support for greater customization control.

* **Improvements**
  * Enhanced theme editor preview with improved token mapping and display capabilities.
  * Updated documentation to reflect expanded theming options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->