### PR TITLE
fix(employees): consistent "Employee Code" label across List/Show/Edit/Bulk

### DIFF
--- a/src/resources/employees/EmployeeBulkImport.tsx
+++ b/src/resources/employees/EmployeeBulkImport.tsx
@@ -276,7 +276,7 @@ export function EmployeeBulkImport() {
   );
 
   const handleDownloadCreds = useCallback(() => {
-    const rowsOut = [['Name', 'Username', 'Mobile', 'Password']];
+    const rowsOut = [['Name', 'Employee Code', 'Mobile', 'Password']];
     for (const emp of createdEmployees) {
       rowsOut.push([emp.user.name, emp.user.userName, emp.user.mobileNumber, 'eGov@123']);
     }

--- a/src/resources/employees/EmployeeEdit.tsx
+++ b/src/resources/employees/EmployeeEdit.tsx
@@ -231,7 +231,6 @@ export function EmployeeEdit() {
       <FieldSection title="Employee Info">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <DigitFormInput source="code" label="Employee Code" disabled />
-          <DigitFormInput source="user.userName" label="Username" disabled />
           <DigitFormInput source="user.name" label="Name" validate={v.name} />
           <DigitFormInput
             source="user.mobileNumber"

--- a/src/resources/employees/EmployeeList.tsx
+++ b/src/resources/employees/EmployeeList.tsx
@@ -18,11 +18,11 @@ const filters = [
     ]}
     alwaysOn
   />,
-  <TextFilterInput key="code" source="code" label="Code" />,
+  <TextFilterInput key="code" source="code" label="Employee Code" />,
 ];
 
 const columns: DigitColumn[] = [
-  { source: 'code', label: 'app.fields.code' },
+  { source: 'code', label: 'Employee Code' },
   { source: 'user.name', label: 'app.fields.name' },
   { source: 'user.mobileNumber', label: 'app.fields.mobile' },
   {

--- a/src/resources/employees/EmployeeShow.tsx
+++ b/src/resources/employees/EmployeeShow.tsx
@@ -27,7 +27,7 @@ export function EmployeeShow() {
           <div className="space-y-6">
             {/* Header Section */}
             <FieldSection title="Employee Info">
-              <FieldRow label="Code">{String(rec.code ?? '')}</FieldRow>
+              <FieldRow label="Employee Code">{String(rec.code ?? '')}</FieldRow>
               <FieldRow label="Name">{String(user?.name ?? '')}</FieldRow>
               <FieldRow label="Mobile">{String(user?.mobileNumber ?? '')}</FieldRow>
               <FieldRow label="Status"><StatusChip value={rec.employeeStatus} /></FieldRow>
@@ -36,9 +36,10 @@ export function EmployeeShow() {
               <FieldRow label="Date of Appointment"><DateField value={rec.dateOfAppointment} showTime={false} /></FieldRow>
             </FieldSection>
 
-            {/* User Section */}
+            {/* User Account. user.userName intentionally omitted — HRMS
+                overwrites it with rec.code, so showing it as "Username" just
+                duplicates "Employee Code" under a misleading label (#460). */}
             <FieldSection title="User Account">
-              <FieldRow label="Username">{String(user?.userName ?? '')}</FieldRow>
               <FieldRow label="Gender">{String(user?.gender ?? '--')}</FieldRow>
               <FieldRow label="Date of Birth"><DateField value={user?.dob} showTime={false} /></FieldRow>
               <FieldRow label="Email">{String(user?.emailId ?? '--')}</FieldRow>


### PR DESCRIPTION
## Summary
Follow-up to [egovernments/Citizen-Complaint-Resolution-System#460](https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/460). The Create form already labels this field "Employee Code", but the rest of the employee surfaces still showed the same value under "Username" or plain "Code", which is what was flagged in the latest comment on that ticket.

HRMS' `enrichUser()` overwrites `user.userName` with `rec.code` server-side, so the Username display rows weren't just inconsistently labeled — they were a literal duplicate of the Employee Code under a misleading name. I dropped those rows instead of renaming them.

## Changes
- **`EmployeeShow.tsx`**: rename "Code" → "Employee Code"; drop the duplicate "Username" row from the User Account section.
- **`EmployeeEdit.tsx`**: drop the disabled "Username" field; "Employee Code" already shows the same value.
- **`EmployeeList.tsx`**: column + filter use literal `"Employee Code"` (instead of the shared `app.fields.code` translation key, which resolves to "Code" and is used by other resources).
- **`EmployeeBulkImport.tsx`**: credentials CSV header "Username" → "Employee Code". The value comes from `emp.user.userName`, which HRMS has already coerced to the code, so the column was misnamed.

Out of scope (deliberately):
- `users/` resource (UserCreate / UserEdit / UserShow / UserList) — those are for raw user records (citizens etc.), where "Username" is still a meaningful label distinct from "Employee Code".
- `app.fields.code` global translation — used by Department / Designation / Role lists where plain "Code" is correct. Only the employees list overrides it inline.

## Test plan
- [ ] Open `/manage/employees` — column + filter both say "Employee Code".
- [ ] Open an employee detail (`Show`) — "Employee Code" appears in the Employee Info section; no "Username" row in User Account.
- [ ] Open an employee Edit form — only one "Employee Code" disabled field, no Username.
- [ ] Run the bulk import flow, click "Download credentials" — CSV header is "Employee Code", not "Username".
- [ ] Existing e2e (`e2e/tests/employees.test.mjs`) still passes — it already targets `"Employee Code"` for the Create form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the employee code field labeling throughout the application to improve consistency and clarity across all employee management features
  * Removed the username field from employee information displays and edit forms, as this value is automatically managed by the system
  * Updated CSV export headers to reflect the revised field naming conventions for employee data downloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->