### PR TITLE
fix: #459 dept/desig tenant scoping + #483 boolean Edit field

### DIFF
--- a/packages/data-provider/src/providers/dataProvider.ts
+++ b/packages/data-provider/src/providers/dataProvider.ts
@@ -51,10 +51,24 @@ function clientSort(records: RaRecord[], field: string, order: string): RaRecord
   });
 }
 
+// Internal filter key allowing a caller to pin a single getList to a tenant
+// other than the session tenant (e.g. EmployeeCreate's dept/desig pickers,
+// where the form lets the operator pick a target tenant that differs from
+// the session ADMIN tenant).
+const TENANT_OVERRIDE_KEY = '__tenantId';
+
+function pickTenant(tenantId: string, filter?: Record<string, unknown>): string {
+  const override = filter?.[TENANT_OVERRIDE_KEY];
+  return typeof override === 'string' && override.trim() ? override.trim() : tenantId;
+}
+
 function clientFilter(records: RaRecord[], filter: Record<string, unknown>): RaRecord[] {
   if (!filter || Object.keys(filter).length === 0) return records;
   return records.filter((record) =>
     Object.entries(filter).every(([key, value]) => {
+      // Internal control keys never participate in record-level filtering;
+      // they're consumed by fetchers (e.g. mdmsGetList honours __tenantId).
+      if (key === TENANT_OVERRIDE_KEY) return true;
       if (key === 'q' && typeof value === 'string') {
         const q = value.toLowerCase();
         return JSON.stringify(record).toLowerCase().includes(q);
@@ -72,8 +86,9 @@ function clientPaginate(records: RaRecord[], page: number, perPage: number): RaR
 
 // --- Service-specific fetchers ---
 
-async function mdmsGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string): Promise<RaRecord[]> {
-  const records = await client.mdmsSearch(tenantId, config.schema!, { limit: 500 });
+async function mdmsGetList(client: DigitApiClient, config: ResourceConfig, tenantId: string, filter?: Record<string, unknown>): Promise<RaRecord[]> {
+  const tenant = pickTenant(tenantId, filter);
+  const records = await client.mdmsSearch(tenant, config.schema!, { limit: 500 });
   return records.filter((r) => r.isActive).map((r) => normalizeMdmsRecord(r, config));
 }
 
@@ -339,7 +354,7 @@ export function createDigitDataProvider(client: DigitApiClient, tenantId: string
   async function fetchAll(resource: string, filter?: Record<string, unknown>): Promise<RaRecord[]> {
     const config = resolveConfig(resource);
     switch (config.type) {
-      case 'mdms': return mdmsGetList(client, config, tenantId);
+      case 'mdms': return mdmsGetList(client, config, tenantId, filter);
       case 'hrms': return hrmsGetList(client, config, tenantId);
       case 'boundary': return boundaryGetList(client, config, tenantId);
       case 'pgr': return pgrGetList(client, config, tenantId, filter);

--- a/src/admin/MdmsResourceEdit.tsx
+++ b/src/admin/MdmsResourceEdit.tsx
@@ -1,5 +1,6 @@
 import { DigitEdit } from './DigitEdit';
 import { DigitFormInput } from './DigitFormInput';
+import { BooleanInput } from './widgets/BooleanInput';
 import { WidgetForFieldSpec } from './widgets';
 import { useEditContext, useResourceContext } from 'ra-core';
 import { getResourceConfig, getResourceLabel } from '@/providers/bridge';
@@ -42,6 +43,14 @@ function MdmsEditFields() {
 
         // Skip complex objects the descriptor didn't handle — same behavior as before.
         if (value != null && typeof value === 'object') return null;
+
+        // Boolean fields must render as a checkbox so the form value stays a
+        // real bool. Falling back to a text input lets operators type 'false',
+        // which the MDMS JSON Schema rejects with `expected type: Boolean,
+        // found: String` (closes egovernments/CCRS#483).
+        if (typeof value === 'boolean') {
+          return <BooleanInput key={key} source={key} label={displayKey} />;
+        }
 
         return (
           <DigitFormInput

--- a/src/resources/employees/AssignmentEditor.tsx
+++ b/src/resources/employees/AssignmentEditor.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { useInput, useGetList, type RaRecord } from 'ra-core';
 import { Plus, Trash2 } from 'lucide-react';
 import {
@@ -66,14 +67,25 @@ export function AssignmentEditor({
     return (field.value as unknown[]).map(toAssignmentRow);
   }, [field.value]);
 
+  // Pin the dept/desig fetches to the tenant the operator picked in the
+  // form. Without this, the pickers list MDMS records from the session
+  // tenant (root `ke` for ADMIN), but HRMS validates the submitted code
+  // against the target tenant — picking root-only codes drops every
+  // create with ERR_HRMS_INVALID_DEPT.
+  const formContext = useFormContext();
+  const formTenantId = useWatch({ control: formContext?.control, name: 'tenantId' }) as
+    | string
+    | undefined;
+  const tenantFilter = formTenantId ? { __tenantId: formTenantId } : undefined;
+
   const { data: departments, isLoading: departmentsLoading } = useGetList<NamedRecord>(
     'departments',
-    { pagination: { page: 1, perPage: 1000 }, sort: { field: 'name', order: 'ASC' } },
+    { pagination: { page: 1, perPage: 1000 }, sort: { field: 'name', order: 'ASC' }, filter: tenantFilter },
   );
 
   const { data: designations, isLoading: designationsLoading } = useGetList<NamedRecord>(
     'designations',
-    { pagination: { page: 1, perPage: 1000 }, sort: { field: 'name', order: 'ASC' } },
+    { pagination: { page: 1, perPage: 1000 }, sort: { field: 'name', order: 'ASC' }, filter: tenantFilter },
   );
 
   const writeRows = (next: EmployeeAssignment[]) => {


### PR DESCRIPTION
Closes two configurator-board items.

## #459 — User created for incorrect tenant id

Round 1 (PR #34, already merged): \`EmployeeCreate.transform\` was clobbering the form-picked \`tenantId\` with the session tenant, so every Create landed at the session tenant.

Round 2 (this PR): even with the transform fixed, raw API tests against \`ke.nairobi\` failed with \`ERR_HRMS_INVALID_DEPT\` because the dept/desig pickers themselves still fetched at the session tenant. An ADMIN logged in at root \`ke\` saw root-only department codes, picked one, and HRMS rejected on the \`ke.nairobi\` write.

**Fix:** add a per-call tenant override to the data provider via an internal \`__tenantId\` filter key. \`AssignmentEditor\` watches the form's \`tenantId\` (via \`useFormContext\` + \`useWatch\`) and threads it through. \`mdmsGetList\` resolves the effective tenant through a new \`pickTenant\` helper; \`clientFilter\` ignores the override key so it doesn't leak into record-level filtering.

## #483 — Boolean master-data field shows as text

\`MdmsResourceEdit\`'s generic field loop fell back to \`DigitFormInput\` (text) for any scalar, including booleans. Editing \`gender-types/TRANSGENDER\` and toggling \`active\` would submit the literal string \`\"false\"\`, which the MDMS schema rejects: \`expected type: Boolean, found: String\`.

**Fix:** when the record value is a boolean, render \`BooleanInput\` (real checkbox bound to the form bool). Create path already handles this via the JSON-Schema-driven branch.

## Verified
- Built and rsynced \`dist/\` to \`/var/www/configurator/\` on Nairobi (\`naipepea.digit.org\`) and Bomet (\`bometfeedbackhub.digit.org\`).
- Raw HRMS \`/employees/_create\` against \`ke.nairobi\` with valid dept/desig codes (\`DEPT_03\`, \`DESIG_01\`) succeeds and lands at the right tenant.