### PR TITLE
fix(branding): surface filestore error + tighten upload allowlist (#467)

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -203,14 +203,24 @@ class DigitApiClient {
       body: formData,
     });
 
-    if (!response.ok) {
-      throw new Error(`File upload failed: ${response.status}`);
+    // Parse the body either way — filestore returns helpful messages on 4xx
+    // (e.g. "extension does not match the file format") that we should
+    // surface to the user instead of dropping in favour of a bare status code.
+    let data: { files?: Array<{ fileStoreId: string; fileName: string }>; Errors?: ApiError[] } | null = null;
+    try {
+      data = await response.json();
+    } catch {
+      // Non-JSON body (rare); fall through to the status-only error below.
     }
 
-    const data = await response.json();
+    if (!response.ok) {
+      const serverMsg = data?.Errors?.[0]?.message;
+      throw new Error(serverMsg || `File upload failed: ${response.status}`);
+    }
+
     return {
-      fileStoreId: data.files[0].fileStoreId,
-      fileName: data.files[0].fileName,
+      fileStoreId: data!.files![0].fileStoreId,
+      fileName: data!.files![0].fileName,
     };
   }
 }

--- a/src/pages/Phase1Page.tsx
+++ b/src/pages/Phase1Page.tsx
@@ -220,12 +220,18 @@ export default function Phase1Page() {
     setLoading(true);
     setError(null);
 
-    // Basic client-side guard so users see the obvious cases instantly
-    // instead of waiting for a filestore round-trip.
-    if (!file.type.startsWith('image/')) {
+    // Mirror egov-filestore's ALLOWED_FORMATS_MAP for image uploads so users
+    // see the obvious cases instantly instead of waiting for a 400.
+    // Browser-reported MIME (file.type) is set when the file was saved with a
+    // matching extension, but is not authoritative — the backend re-detects
+    // via Tika and rejects extension/content mismatches with a separate 400.
+    const ALLOWED_EXTS = ['jpg', 'jpeg', 'png', 'svg'];
+    const ALLOWED_MIMES = ['image/jpeg', 'image/jpg', 'image/png', 'image/svg+xml'];
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+    if (!ALLOWED_EXTS.includes(ext) || (file.type && !ALLOWED_MIMES.includes(file.type))) {
       setBrandingErrors(prev => ({
         ...prev,
-        [type]: `Expected an image file, got "${file.type || 'unknown'}".`,
+        [type]: `Use JPG, PNG, or SVG (got "${file.name}"${file.type ? `, ${file.type}` : ''}). Many phone-camera images are HEIC/WebP — re-export as JPG.`,
       }));
       setLoading(false);
       return;


### PR DESCRIPTION
## Summary

Fixes **egovernments/Citizen-Complaint-Resolution-System#467** — *"Upload Logo Image feature not working"*.

The reporter saw an opaque `File upload failed: 400` on Step 1.2 when uploading what looked like a JPEG. Verified end-to-end on `https://naipepea.digit.org/configurator/` with the live `apiClient.uploadFile` code path — the file in question was almost certainly a non-JPEG (WebP/HEIC/AVIF) saved with a `.jpeg` extension, common when files come from a phone camera or share-sheet export.

Two fixes:

1. **`src/api/client.ts` `uploadFile`** — parse the response body either way and surface filestore's `Errors[0].message` (e.g. *"extension does not match the file format. Please upload any of the allowed formats: [jpg, jpeg, png, svg, ...]"*) instead of dropping it for a bare status code.
2. **`src/pages/Phase1Page.tsx` `handleBrandingFileUpload`** — replace the permissive `file.type.startsWith('image/')` guard with an explicit allowlist matching egov-filestore's `ALLOWED_FORMATS_MAP` (`jpg/jpeg/png/svg`) plus an extension check, so HEIC/WebP and renamed-extension files fail inline before the network call.

## Reproduction (in browser, before this PR)

Logged into the live configurator and ran the same code path `apiClient.uploadFile` runs:

| File | Status | Result |
|---|---|---|
| `logo.jpg` (real JPEG) | 201 | ✅ |
| `LOGO.JPG` (uppercase) | 201 | ✅ |
| `logo.png` (real PNG) | 201 | ✅ |
| `logo.webp` (real WebP) | 400 | ❌ `please upload any of the allowed formats: [jpg, jpeg, png, ...]` |
| `header-logo.jpeg` (WebP bytes, `.jpeg` ext) | 400 | ❌ `extension does not match the file format` |

Pre-fix, both 400 cases collapsed to a single opaque `File upload failed: 400` for the user. Post-fix, the user sees the actionable message inline.

## Test plan

- [x] `npx vite build --base=/configurator/` clean (data-provider built first)
- [ ] Manual on `https://naipepea.digit.org/configurator/phase/1`: upload a real JPG, real PNG, real SVG → all should succeed
- [ ] Manual: upload a `.webp` → should fail inline *before* hitting the network with "Use JPG, PNG, or SVG"
- [ ] Manual: upload a WebP renamed to `.jpeg` → should hit the backend and surface "extension does not match the file format"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced file upload error messages to display server-provided error details when available, with improved fallback handling.
* Improved branding image format validation to support only JPG, PNG, and SVG files, with clearer guidance for users regarding common mobile device image formats (HEIC, WebP).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->