### PR TITLE
fix: #468 wire Download Template buttons in Phases 2/3/4

### DIFF
--- a/src/pages/Phase2Page.tsx
+++ b/src/pages/Phase2Page.tsx
@@ -28,6 +28,7 @@ import { SubmitBar } from '@/components/digit/SubmitBar';
 import { Banner } from '@/components/digit/Banner';
 import { boundaryService, localizationService, ApiClientError } from '@/api';
 import { parseExcelFile, parseBoundaryExcel } from '@/utils/excelParser';
+import { downloadBoundaryTemplate } from '@/utils/templateBuilder';
 import type { BoundaryHierarchy, Boundary, BoundaryExcelRow } from '@/api/types';
 
 type Step = 'landing' | 'create-hierarchy' | 'select-hierarchy' | 'template' | 'upload' | 'verify' | 'complete';
@@ -275,14 +276,17 @@ export default function Phase2Page() {
     navigate('/phase/3');
   };
 
-  const handleDownloadTemplate = () => {
-    // For now, just show an alert about the template
-    alert('Template download would start here.');
-  };
-
   const getHierarchyLevels = (hierarchy: BoundaryHierarchy): string[] => {
     if (!hierarchy.boundaryHierarchy) return [];
     return hierarchy.boundaryHierarchy.map(level => level.boundaryType);
+  };
+
+  const handleDownloadTemplate = () => {
+    const levels = selectedHierarchy
+      ? getHierarchyLevels(selectedHierarchy)
+      : hierarchyLevels;
+    const type = selectedHierarchy?.hierarchyType || hierarchyType || 'ADMIN';
+    downloadBoundaryTemplate(type, levels);
   };
 
   return (

--- a/src/pages/Phase3Page.tsx
+++ b/src/pages/Phase3Page.tsx
@@ -31,6 +31,7 @@ import {
   parseDesignationExcel,
   parseComplaintTypeExcel,
 } from '@/utils/excelParser';
+import { downloadCommonMastersTemplate } from '@/utils/templateBuilder';
 import type {
   DepartmentExcelRow,
   DesignationExcelRow,
@@ -230,7 +231,7 @@ export default function Phase3Page() {
   };
 
   const handleDownloadTemplate = () => {
-    alert('Template download would start here.');
+    downloadCommonMastersTemplate();
   };
 
   return (

--- a/src/pages/Phase4Page.tsx
+++ b/src/pages/Phase4Page.tsx
@@ -36,6 +36,7 @@ import {
   ApiClientError,
 } from '@/api';
 import { parseExcelFile, parseEmployeeExcel } from '@/utils/excelParser';
+import { downloadEmployeeTemplate } from '@/utils/templateBuilder';
 import type {
   EmployeeExcelRow,
   Employee,
@@ -306,7 +307,7 @@ export default function Phase4Page() {
   };
 
   const handleDownloadTemplate = () => {
-    alert('Template download would start here.');
+    downloadEmployeeTemplate();
   };
 
   const handleDownloadCredentials = () => {

--- a/src/utils/templateBuilder.ts
+++ b/src/utils/templateBuilder.ts
@@ -1,0 +1,95 @@
+import * as XLSX from 'xlsx';
+import { triggerDownload } from '@/admin/bulk/BulkImportPanel';
+
+type Row = Array<string | number>;
+
+function buildSheet(header: string[], rows: Row[]): XLSX.WorkSheet {
+  const aoa: (string | number)[][] = [header, ...rows];
+  const ws = XLSX.utils.aoa_to_sheet(aoa);
+  ws['!cols'] = header.map((h) => ({ wch: Math.max(14, h.length + 2) }));
+  return ws;
+}
+
+function writeWorkbook(wb: XLSX.WorkBook): Blob {
+  const buf = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+  return new Blob([buf], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+}
+
+export function downloadBoundaryTemplate(hierarchyType: string, levels: string[]) {
+  const safeLevels = levels.length > 0 ? levels : ['Country', 'State', 'City', 'Ward'];
+  const header = ['code', 'name', 'boundaryType', 'parentCode', 'latitude', 'longitude'];
+  const sample: Row[] = safeLevels.map((level, i) => {
+    const code = `${level.toUpperCase().replace(/\s+/g, '_')}_001`;
+    const parent = i === 0 ? '' : `${safeLevels[i - 1].toUpperCase().replace(/\s+/g, '_')}_001`;
+    return [code, `Sample ${level}`, level, parent, '', ''];
+  });
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, buildSheet(header, sample), 'Boundary');
+  const filename = `Boundary_Template_${hierarchyType || 'ADMIN'}.xlsx`;
+  triggerDownload(writeWorkbook(wb), filename);
+}
+
+export function downloadCommonMastersTemplate() {
+  const wb = XLSX.utils.book_new();
+
+  const deptHeader = ['code', 'name', 'active'];
+  const deptRows: Row[] = [
+    ['ENV', 'Environment', 'true'],
+    ['WORKS', 'Public Works', 'true'],
+  ];
+  XLSX.utils.book_append_sheet(wb, buildSheet(deptHeader, deptRows), 'Department');
+
+  const desigHeader = ['code', 'name', 'description', 'department', 'active'];
+  const desigRows: Row[] = [
+    ['OFFICER', 'Officer', 'Field Officer', 'ENV', 'true'],
+    ['INSPECTOR', 'Inspector', 'Senior Inspector', 'ENV,WORKS', 'true'],
+  ];
+  XLSX.utils.book_append_sheet(wb, buildSheet(desigHeader, desigRows), 'Designation');
+
+  const ctHeader = ['serviceCode', 'name', 'keywords', 'department', 'slaHours', 'active'];
+  const ctRows: Row[] = [
+    ['POTHOLE', 'Pothole Repair', 'pothole,road', 'WORKS', 120, 'true'],
+    ['GARBAGE', 'Garbage Collection', 'garbage,waste', 'ENV', 48, 'true'],
+  ];
+  XLSX.utils.book_append_sheet(wb, buildSheet(ctHeader, ctRows), 'ComplaintType');
+
+  triggerDownload(writeWorkbook(wb), 'Common_and_Complaint_Master.xlsx');
+}
+
+export function downloadEmployeeTemplate() {
+  const header = [
+    'employeeCode',
+    'name',
+    'userName',
+    'mobileNumber',
+    'emailId',
+    'gender',
+    'dob',
+    'department',
+    'designation',
+    'roles',
+    'jurisdictions',
+    'dateOfAppointment',
+  ];
+  const rows: Row[] = [
+    [
+      'EMP001',
+      'Jane Doe',
+      'jane.doe',
+      '9000000001',
+      'jane@example.com',
+      'FEMALE',
+      '1990-01-15',
+      'ENV',
+      'OFFICER',
+      'EMPLOYEE,GRO',
+      'WARD_001',
+      '2024-06-01',
+    ],
+  ];
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, buildSheet(header, rows), 'Employee');
+  triggerDownload(writeWorkbook(wb), 'Employee_Template.xlsx');
+}


### PR DESCRIPTION
## Summary

- Closes egovernments/Citizen-Complaint-Resolution-System#468
- `handleDownloadTemplate` in Phase 2 (Boundary), Phase 3 (Common Masters) and Phase 4 (Employee) was a stub: `alert('Template download would start here.')`. Reporters got a native browser dialog with an OK button and **no file ever downloaded**. Issue #468 reports the boundary case — the same bug existed in all three phases.
- Adds `src/utils/templateBuilder.ts` with three builders that emit XLSX workbooks matching the column shapes the existing parsers in `src/utils/excelParser.ts` already accept, and triggers the download via the existing `triggerDownload` helper from `src/admin/bulk/BulkImportPanel.tsx`.
- Reuses `xlsx@^0.18.5` already in `package.json` — no new deps.

### Templates produced
| Phase | Filename | Sheets / columns |
|---|---|---|
| 2 — Boundary | `Boundary_Template_<HIERARCHY>.xlsx` | `Boundary`: code, name, boundaryType, parentCode, latitude, longitude — sample rows seeded from chosen hierarchy levels |
| 3 — Common Masters | `Common_and_Complaint_Master.xlsx` | `Department` / `Designation` / `ComplaintType` — three sheets matching `parseDepartmentExcel` / `parseDesignationExcel` / `parseComplaintTypeExcel` |
| 4 — Employee | `Employee_Template.xlsx` | `Employee` — full column set parsed by `parseEmployeeExcel` |

## Validation
- Reproduced #468 against `https://naipepea.digit.org/configurator/` (current bundle `index-D7Spg7Fi.js`) by creating a `REVENUE` hierarchy with `County → Sub county → Wards`. Stubbed `window.alert` and confirmed only payload was the literal string `Template download would start here.`, with zero network calls and zero `<a download>` clicks.
- Ran `npx vite build --base=/configurator/` — clean. Ran `npx vitest run` — 22/22 pass.
- ESLint diff is clean; the 4 pre-existing warnings/errors on `Phase4Page.tsx` (`fetchReferenceData` hoisting) are not touched by this PR.

## Test plan
- [ ] Pull, rebuild, deploy to `naipepea.digit.org/configurator/`
- [ ] Phase 2: create REVENUE hierarchy → click Download Template → verify `Boundary_Template_REVENUE.xlsx` downloads with sample rows for `County / Sub county / Wards`
- [ ] Phase 3 landing → click Download Template → verify `Common_and_Complaint_Master.xlsx` opens with three sheets
- [ ] Phase 4: click Download Template → verify `Employee_Template.xlsx` opens with all required columns
- [ ] Round-trip: re-upload each downloaded template (after filling sample data) and confirm parsers in `excelParser.ts` accept the column shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)