### PR TITLE
fix(create+edit): redirect after success when custom onSuccess is set (CCRS#471)

### DIFF
--- a/src/admin/DigitCreate.tsx
+++ b/src/admin/DigitCreate.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CreateBase, useCreateContext, Form, useResourceContext, type TransformData, type RaRecord } from 'ra-core';
+import { CreateBase, useCreateContext, Form, useResourceContext, useRedirect, type TransformData, type RaRecord } from 'ra-core';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Save, RefreshCw } from 'lucide-react';
 import { DigitCard } from '@/components/digit/DigitCard';
@@ -118,12 +118,17 @@ function DigitCreateContent({
 export function DigitCreate({ title, children, resource, record, redirect = 'list', transform }: DigitCreateProps) {
   const { info, capture, clear } = useMutationError();
   const contextResource = useResourceContext();
+  const redirectTo = useRedirect();
   const effectiveResource = resource ?? contextResource;
   return (
     <CreateBase
       resource={resource}
       record={record}
-      redirect={redirect}
+      // Don't pass `redirect` to CreateBase — when `mutationOptions.onSuccess`
+      // is provided, ra-core treats it as a full override of the default
+      // post-create handler and skips its built-in redirect step. We need
+      // the toast (next block) AND the redirect, so we drive the redirect
+      // ourselves from inside onSuccess.
       transform={transform}
       mutationOptions={{
         onError: (err) => capture(err),
@@ -137,6 +142,14 @@ export function DigitCreate({ title, children, resource, record, redirect = 'lis
             title: `${prettyResourceSingular(effectiveResource)} created`,
             description: label !== 'Record' ? label : undefined,
           });
+          // Manually fire the redirect since our custom onSuccess swallows
+          // ra-core's default redirect side-effect. Without this the form
+          // stayed populated after a successful create, leaving operators
+          // confused about whether the submit actually went through
+          // (closes egovernments/CCRS#471).
+          if (redirect && effectiveResource) {
+            redirectTo(redirect, effectiveResource, (data as RaRecord | undefined)?.id, data as RaRecord | undefined);
+          }
         },
       }}
     >

--- a/src/admin/DigitEdit.tsx
+++ b/src/admin/DigitEdit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { EditBase, useEditContext, Form, useResourceContext, type TransformData, type RaRecord } from 'ra-core';
+import { EditBase, useEditContext, Form, useResourceContext, useRedirect, type TransformData, type RaRecord } from 'ra-core';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Save, RefreshCw } from 'lucide-react';
 import { DigitCard } from '@/components/digit/DigitCard';
@@ -37,6 +37,8 @@ export interface DigitEditProps {
   resource?: string;
   /** Record id (optional, from URL by default) */
   id?: string | number;
+  /** Where to redirect after successful update (default: "list") */
+  redirect?: 'list' | 'edit' | 'show' | false;
   /** Optional pre-submit transform */
   transform?: TransformData;
 }
@@ -157,15 +159,19 @@ function DigitEditContent({
   );
 }
 
-export function DigitEdit({ title, children, resource, id, transform }: DigitEditProps) {
+export function DigitEdit({ title, children, resource, id, redirect = 'list', transform }: DigitEditProps) {
   const { info, capture, clear } = useMutationError();
   const contextResource = useResourceContext();
+  const redirectTo = useRedirect();
   const effectiveResource = resource ?? contextResource;
   return (
     <EditBase
       resource={resource}
       id={id}
       mutationMode="pessimistic"
+      // See note in DigitCreate: ra-core treats a custom mutationOptions.onSuccess
+      // as a full override of its post-update handler and silently drops the
+      // built-in redirect. Drive the redirect ourselves from inside onSuccess.
       transform={transform}
       mutationOptions={{
         onError: (err) => capture(err),
@@ -176,6 +182,9 @@ export function DigitEdit({ title, children, resource, id, transform }: DigitEdi
             title: `${prettyResourceSingular(effectiveResource)} updated`,
             description: label !== 'Record' ? label : undefined,
           });
+          if (redirect && effectiveResource) {
+            redirectTo(redirect, effectiveResource, (data as RaRecord | undefined)?.id, data as RaRecord | undefined);
+          }
         },
       }}
     >


### PR DESCRIPTION
## Diagnosis

After creating or editing a record via Configurator, the form stayed populated and the user wasn't redirected to the list view. The 200 response would briefly flash a toast and then... nothing — operators couldn't tell whether the submit went through.

Root cause: both `DigitCreate` and `DigitEdit` pass a custom `mutationOptions.onSuccess` to ra-core's `CreateBase` / `EditBase` (so we can show a toast). When ra-core sees a custom `onSuccess`, it treats it as a **full override** of the default post-mutation handler and silently drops its built-in redirect.

## Fix

Drive the redirect ourselves from inside `onSuccess`, after the toast fires — applied to both `DigitCreate` and `DigitEdit`:

- Don't pass `redirect` to `CreateBase` / `EditBase` (it's ignored anyway when `onSuccess` is custom).
- Call `useRedirect()` and invoke it at the end of `onSuccess` with the resolved `redirect` target, resource and record id.
- Add a `redirect` prop to `DigitEditProps` (default `'list'`, matching `DigitCreate`).

## Test plan

- [x] Local Configurator dev server, login as ke.nairobi admin.
- [x] **Create**: navigate to `/configurator/manage/departments/create`, fill Name + Code, click Create. `POST /mdms-v2/v2/_create/common-masters.Department` → `202`, browser navigated `/departments/create` → `/departments`.
- [x] **Edit**: navigate to `/configurator/manage/employees/<id>/edit`, click Save without changes. Browser navigated `/employees/<id>/edit` → `/employees`.
- [x] Same fix applies to every resource using `DigitCreate` / `DigitEdit` (employees, complaint types, designations, boundary hierarchies, localization, users, etc.) since both are shared components.

Closes egovernments/CCRS#471