### PR TITLE
feat(localization): bulk import + export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1310,6 +1311,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1331,6 +1333,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1340,12 +1343,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1362,6 +1367,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1375,6 +1381,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1384,6 +1391,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3426,27 +3434,6 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -3522,14 +3509,6 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3621,7 +3600,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3631,7 +3610,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4173,12 +4152,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4192,6 +4173,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4439,6 +4421,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4462,6 +4445,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4575,6 +4559,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4657,6 +4642,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4681,6 +4667,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4782,6 +4769,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4904,6 +4892,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4942,7 +4931,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -5106,21 +5095,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "license": "MIT"
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.4.0",
@@ -5243,7 +5226,7 @@
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5599,6 +5582,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5615,6 +5599,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5641,6 +5626,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -5679,6 +5665,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -5761,6 +5748,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -5866,7 +5854,7 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -5894,6 +5882,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6108,6 +6097,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -6120,6 +6110,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6135,6 +6126,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6154,6 +6146,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -6166,6 +6159,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -6189,6 +6183,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -6344,6 +6339,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -6356,6 +6352,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -6424,17 +6421,6 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6465,6 +6451,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -6474,6 +6461,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6524,6 +6512,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -6535,6 +6524,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6591,6 +6581,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6600,6 +6591,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6609,6 +6601,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6812,6 +6805,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -6832,12 +6826,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6850,6 +6846,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6859,6 +6856,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6900,6 +6898,7 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6928,6 +6927,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -6945,6 +6945,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6970,6 +6971,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7012,6 +7014,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7037,6 +7040,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -7050,6 +7054,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/posthog-js": {
@@ -7091,36 +7096,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/progress": {
@@ -7284,6 +7259,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7408,14 +7384,6 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -7537,6 +7505,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -7546,6 +7515,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -7592,6 +7562,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7623,7 +7594,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -7633,6 +7604,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7688,6 +7660,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7845,6 +7818,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7964,6 +7938,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -7999,6 +7974,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8028,6 +8004,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -8122,6 +8099,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -8131,6 +8109,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -8160,6 +8139,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -8176,6 +8156,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -8193,6 +8174,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8235,6 +8217,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -8286,6 +8269,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -8298,7 +8282,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -8325,7 +8309,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -8482,6 +8465,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ import {
   EmployeeList, EmployeeShow, EmployeeEdit, EmployeeCreate, EmployeeBulkImport,
   ComplaintList, ComplaintShow, ComplaintEdit, ComplaintCreate,
   BoundaryList, BoundaryShow, BoundaryEdit, BoundaryCreate,
-  LocalizationList, LocalizationShow, LocalizationEdit, LocalizationCreate,
+  LocalizationList, LocalizationShow, LocalizationEdit, LocalizationCreate, LocalizationBulkImport,
   UserList, UserShow, UserEdit, UserCreate,
   AccessRoleList, AccessRoleShow,
   AccessActionList, AccessActionShow,
@@ -142,6 +142,7 @@ function ManagementAdmin() {
           <Route path="/employees/bulk" element={<EmployeeBulkImport />} />
           <Route path="/departments/bulk" element={<DepartmentBulkImport />} />
           <Route path="/designations/bulk" element={<DesignationBulkImport />} />
+          <Route path="/localization/bulk" element={<LocalizationBulkImport />} />
         </CustomRoutes>
       </CoreAdminUI>
     </CoreAdminContext>

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -34,6 +34,10 @@ export const ENDPOINTS = {
   // Localization
   LOCALIZATION_SEARCH: '/localization/messages/v1/_search',
   LOCALIZATION_UPSERT: '/localization/messages/v1/_upsert',
+  // Localization service caches per-tenant in memory; without this call
+  // after a write, `_search` (and the digit-ui's localStorage cache) keep
+  // returning the pre-write snapshot until restart.
+  LOCALIZATION_CACHE_BUST: '/localization/messages/cache-bust',
 
   // Filestore
   FILESTORE_UPLOAD: '/filestore/v1/files',

--- a/src/api/services/localization.ts
+++ b/src/api/services/localization.ts
@@ -74,6 +74,20 @@ export const localizationService = {
   },
 
   // ============================================
+  // Cache Bust
+  // ============================================
+
+  /** Tell the localization service to drop its in-memory per-tenant cache.
+   *  Required after every write — without it `_search` keeps returning the
+   *  pre-write snapshot, and the digit-ui's localStorage cache will be
+   *  populated from stale data on next refresh. */
+  async cacheBust(): Promise<void> {
+    await apiClient.post(ENDPOINTS.LOCALIZATION_CACHE_BUST, {
+      RequestInfo: apiClient.buildRequestInfo(),
+    });
+  },
+
+  // ============================================
   // Helper Methods for Different Entity Types
   // ============================================
 

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -31,6 +31,7 @@ export { LocalizationList } from './localization/LocalizationList';
 export { LocalizationShow } from './localization/LocalizationShow';
 export { LocalizationEdit } from './localization/LocalizationEdit';
 export { LocalizationCreate } from './localization/LocalizationCreate';
+export { LocalizationBulkImport } from './localization/LocalizationBulkImport';
 export { AdvancedPage } from './advanced/AdvancedPage';
 export { UserList } from './users/UserList';
 export { UserShow } from './users/UserShow';

--- a/src/resources/localization/LocalizationBulkImport.tsx
+++ b/src/resources/localization/LocalizationBulkImport.tsx
@@ -1,0 +1,380 @@
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Upload,
+  Download,
+  Check,
+  X,
+  Loader2,
+  AlertTriangle,
+  AlertCircle,
+  FileSpreadsheet,
+} from 'lucide-react';
+import * as XLSX from 'xlsx';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { DigitCard } from '@/components/digit/DigitCard';
+import { triggerDownload } from '@/admin/bulk/BulkImportPanel';
+import { localizationService } from '@/api';
+import { useApp } from '../../App';
+import { useAvailableLocales } from '@/hooks/useAvailableLocales';
+
+type Step = 'landing' | 'preview' | 'uploading' | 'complete';
+
+interface ParsedRow {
+  code: string;
+  module: string;
+  locale: string;
+  message: string;
+  status: 'valid' | 'error';
+  error?: string;
+}
+
+const REQUIRED_COLUMNS = ['code', 'module', 'locale', 'message'] as const;
+
+function buildTemplate(tenantId: string, locales: string[]): Blob {
+  const wb = XLSX.utils.book_new();
+
+  const sample = XLSX.utils.aoa_to_sheet([
+    REQUIRED_COLUMNS as unknown as string[],
+    ['EXAMPLE_KEY_HELLO', 'rainmaker-pgr', locales[0] ?? 'en_IN', 'Hello'],
+    ['EXAMPLE_KEY_HELLO', 'rainmaker-pgr', locales[1] ?? 'sw_KE', 'Habari'],
+    ['EXAMPLE_KEY_GOODBYE', 'rainmaker-pgr', locales[0] ?? 'en_IN', 'Goodbye'],
+  ]);
+  sample['!cols'] = [{ wch: 36 }, { wch: 22 }, { wch: 10 }, { wch: 80 }];
+  XLSX.utils.book_append_sheet(wb, sample, 'Localization');
+
+  const notesRows = [
+    ['Localization bulk import template'],
+    [`Tenant: ${tenantId}`],
+    [`Locales registered for this tenant: ${locales.join(', ') || '(none)'}`],
+    [''],
+    ['Required columns (case-sensitive headers, in this order):'],
+    ['  code      The lookup key the UI calls t() with (e.g. CS_REJECT_COMPLAINT).'],
+    ['  module    Localization module — e.g. rainmaker-pgr, rainmaker-common, digit-ui.'],
+    ['  locale    Locale code (en_IN, sw_KE, …). Must be registered on the tenant.'],
+    ['  message   Display text shown to the user. May contain spaces, punctuation, and Unicode.'],
+    [''],
+    ['Behaviour:'],
+    ['  - Rows are upserted: existing (tenant, locale, module, code) tuples are overwritten,'],
+    ['    new ones inserted. Nothing is deleted. To remove a key, ignore this importer and'],
+    ['    use the localization-service _delete endpoint directly.'],
+    ['  - Duplicate (tenant, locale, module, code) rows in one file are deduped — last wins.'],
+    ['  - On success, the localization service cache is busted automatically; users may'],
+    ['    still need to refresh their browser to drop the SPA localStorage cache.'],
+    [''],
+    ['Tip: download an export of the current state, edit messages in Excel, re-upload.'],
+  ];
+  const notes = XLSX.utils.aoa_to_sheet(notesRows);
+  notes['!cols'] = [{ wch: 100 }];
+  XLSX.utils.book_append_sheet(wb, notes, 'Instructions');
+
+  const buf = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+  return new Blob([buf], {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+}
+
+function parseWorkbook(wb: XLSX.WorkBook): { rows: Omit<ParsedRow, 'status' | 'error'>[]; parseError?: string } {
+  const sheetName =
+    wb.SheetNames.find((n) => /localization/i.test(n)) ?? wb.SheetNames[0];
+  if (!sheetName) return { rows: [], parseError: 'Workbook has no sheets.' };
+  const ws = wb.Sheets[sheetName];
+  const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(ws, { defval: '' });
+  if (rows.length === 0) {
+    return { rows: [], parseError: `Sheet "${sheetName}" is empty.` };
+  }
+
+  const firstRow = rows[0];
+  const missing = REQUIRED_COLUMNS.filter((c) => !(c in firstRow));
+  if (missing.length > 0) {
+    return {
+      rows: [],
+      parseError: `Missing required column(s): ${missing.join(', ')}. Expected headers: ${REQUIRED_COLUMNS.join(', ')}.`,
+    };
+  }
+
+  const parsed = rows.map((r) => ({
+    code: String(r.code ?? '').trim(),
+    module: String(r.module ?? '').trim(),
+    locale: String(r.locale ?? '').trim(),
+    message: String(r.message ?? ''),
+  }));
+  return { rows: parsed };
+}
+
+function validateRow(row: Omit<ParsedRow, 'status' | 'error'>, knownLocales: Set<string>): string[] {
+  const errs: string[] = [];
+  if (!row.code) errs.push('code is required');
+  if (!row.module) errs.push('module is required');
+  if (!row.locale) errs.push('locale is required');
+  if (!row.message) errs.push('message is required');
+  if (row.locale && knownLocales.size > 0 && !knownLocales.has(row.locale)) {
+    errs.push(`locale "${row.locale}" is not registered on this tenant`);
+  }
+  return errs;
+}
+
+export function LocalizationBulkImport() {
+  const { state } = useApp();
+  const tenantId = state.tenant;
+  const navigate = useNavigate();
+  const { locales, isLoading: localesLoading } = useAvailableLocales();
+  const knownLocales = new Set(locales.map((l) => l.value));
+
+  const [step, setStep] = useState<Step>('landing');
+  const [error, setError] = useState<string | null>(null);
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  const [rows, setRows] = useState<ParsedRow[]>([]);
+  const [progress, setProgress] = useState(0);
+  const [progressMsg, setProgressMsg] = useState('');
+  const [success, setSuccess] = useState(0);
+  const [failed, setFailed] = useState(0);
+
+  const handleTemplateDownload = useCallback(() => {
+    const blob = buildTemplate(tenantId, locales.map((l) => l.value));
+    triggerDownload(blob, `localization-template-${tenantId}.xlsx`);
+  }, [tenantId, locales]);
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      setError(null);
+      setUploadedFile(file);
+      try {
+        const buf = await file.arrayBuffer();
+        const wb = XLSX.read(new Uint8Array(buf), { type: 'array' });
+        const { rows: parsed, parseError } = parseWorkbook(wb);
+        if (parseError) {
+          setError(parseError);
+          return;
+        }
+        const validated: ParsedRow[] = parsed.map((r) => {
+          const errs = validateRow(r, knownLocales);
+          return {
+            ...r,
+            status: errs.length === 0 ? 'valid' : 'error',
+            error: errs.length > 0 ? errs.join('; ') : undefined,
+          };
+        });
+        setRows(validated);
+        setStep('preview');
+      } catch (e) {
+        console.error('Parse error', e);
+        setError('Failed to parse file. Upload a valid .xlsx, .xls, or .csv.');
+      }
+    },
+    [knownLocales],
+  );
+
+  const handleConfirm = useCallback(async () => {
+    setStep('uploading');
+    setProgress(0);
+    setSuccess(0);
+    setFailed(0);
+
+    const valid = rows.filter((r) => r.status === 'valid');
+
+    // Group by locale; the localization service writes one batch per locale
+    // and dedupes within a batch by (tenant, locale, module, code).
+    const byLocale = new Map<string, ParsedRow[]>();
+    for (const r of valid) {
+      if (!byLocale.has(r.locale)) byLocale.set(r.locale, []);
+      byLocale.get(r.locale)!.push(r);
+    }
+
+    const totalLocales = byLocale.size;
+    let i = 0;
+    let totalSuccess = 0;
+    let totalFailed = 0;
+    for (const [locale, msgs] of byLocale) {
+      i += 1;
+      setProgressMsg(`Upserting ${msgs.length} message${msgs.length === 1 ? '' : 's'} into ${locale} (${i}/${totalLocales})…`);
+      const result = await localizationService.upsertMessages(tenantId, locale, msgs);
+      totalSuccess += result.success;
+      totalFailed += result.failed;
+      setProgress(Math.round((i / (totalLocales + 1)) * 100));
+    }
+
+    setProgressMsg('Busting localization cache…');
+    try {
+      await localizationService.cacheBust();
+    } catch (e) {
+      console.warn('cache-bust failed', e);
+      // Don't block — upserts succeeded; cache will eventually expire.
+    }
+    setProgress(100);
+    setSuccess(totalSuccess);
+    setFailed(totalFailed + (rows.length - valid.length));
+    setStep('complete');
+  }, [rows, tenantId]);
+
+  const validCount = rows.filter((r) => r.status === 'valid').length;
+  const invalidCount = rows.length - validCount;
+
+  return (
+    <div className="container mx-auto py-6 px-4 max-w-5xl">
+      <div className="flex items-center gap-2 mb-4">
+        <Button variant="ghost" size="sm" onClick={() => navigate('/manage/localization')} className="gap-1">
+          <ArrowLeft className="w-4 h-4" />
+          Back to Localization
+        </Button>
+      </div>
+
+      <h1 className="text-2xl font-semibold mb-1">Bulk import localization</h1>
+      <p className="text-sm text-muted-foreground mb-6">
+        Upload an .xlsx/.csv with columns <code>code</code>, <code>module</code>, <code>locale</code>, <code>message</code>. Tenant: <span className="font-mono">{tenantId}</span>.
+      </p>
+
+      {step === 'landing' && (
+        <div className="space-y-4">
+          <DigitCard className="p-6">
+            <div className="flex items-start gap-4">
+              <FileSpreadsheet className="w-8 h-8 text-muted-foreground shrink-0" />
+              <div className="flex-1">
+                <h2 className="font-semibold mb-1">1. Download the template</h2>
+                <p className="text-sm text-muted-foreground mb-3">
+                  Pre-filled with example rows for {locales.map((l) => l.value).join(', ') || 'the default locale'}, plus an Instructions sheet.
+                </p>
+                <Button onClick={handleTemplateDownload} variant="outline" size="sm" className="gap-1.5" disabled={localesLoading}>
+                  <Download className="w-4 h-4" />
+                  Download template
+                </Button>
+              </div>
+            </div>
+          </DigitCard>
+
+          <DigitCard className="p-6">
+            <div className="flex items-start gap-4">
+              <Upload className="w-8 h-8 text-muted-foreground shrink-0" />
+              <div className="flex-1">
+                <h2 className="font-semibold mb-1">2. Upload your file</h2>
+                <p className="text-sm text-muted-foreground mb-3">
+                  Existing keys will be overwritten. Localization service cache is busted automatically on success.
+                </p>
+                <input
+                  type="file"
+                  accept=".xlsx,.xls,.csv"
+                  onChange={(e) => {
+                    const f = e.target.files?.[0];
+                    if (f) void handleUpload(f);
+                  }}
+                  className="block text-sm file:mr-3 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-primary-main file:text-white hover:file:opacity-90 cursor-pointer"
+                />
+              </div>
+            </div>
+          </DigitCard>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="w-4 h-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+      )}
+
+      {step === 'preview' && (
+        <div className="space-y-4">
+          <Alert>
+            <AlertTriangle className="w-4 h-4" />
+            <AlertDescription>
+              <span className="font-medium">{uploadedFile?.name}</span> — {rows.length} rows parsed:{' '}
+              <Badge variant="secondary" className="ml-1">{validCount} valid</Badge>
+              {invalidCount > 0 && <Badge variant="destructive" className="ml-1">{invalidCount} invalid</Badge>}
+            </AlertDescription>
+          </Alert>
+
+          <DigitCard>
+            <div className="max-h-[420px] overflow-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-12">#</TableHead>
+                    <TableHead>code</TableHead>
+                    <TableHead>module</TableHead>
+                    <TableHead>locale</TableHead>
+                    <TableHead>message</TableHead>
+                    <TableHead className="w-24">status</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.slice(0, 200).map((r, i) => (
+                    <TableRow key={i}>
+                      <TableCell className="text-muted-foreground">{i + 1}</TableCell>
+                      <TableCell className="font-mono text-xs">{r.code}</TableCell>
+                      <TableCell className="font-mono text-xs">{r.module}</TableCell>
+                      <TableCell className="font-mono text-xs">{r.locale}</TableCell>
+                      <TableCell className="text-xs max-w-[280px] truncate" title={r.message}>{r.message}</TableCell>
+                      <TableCell>
+                        {r.status === 'valid' ? (
+                          <Badge variant="secondary" className="gap-1"><Check className="w-3 h-3" />ok</Badge>
+                        ) : (
+                          <Badge variant="destructive" className="gap-1" title={r.error}><X className="w-3 h-3" />{r.error}</Badge>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              {rows.length > 200 && (
+                <p className="text-xs text-muted-foreground p-3 text-center">
+                  Showing first 200 of {rows.length} rows.
+                </p>
+              )}
+            </div>
+          </DigitCard>
+
+          <div className="flex gap-2">
+            <Button onClick={handleConfirm} disabled={validCount === 0} className="gap-1.5">
+              <Upload className="w-4 h-4" />
+              Import {validCount} valid {validCount === 1 ? 'row' : 'rows'}
+            </Button>
+            <Button variant="outline" onClick={() => { setStep('landing'); setRows([]); setUploadedFile(null); }}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {step === 'uploading' && (
+        <DigitCard className="p-6">
+          <div className="flex items-center gap-3 mb-3">
+            <Loader2 className="w-5 h-5 animate-spin text-primary-main" />
+            <span className="font-medium">{progressMsg}</span>
+          </div>
+          <Progress value={progress} />
+        </DigitCard>
+      )}
+
+      {step === 'complete' && (
+        <div className="space-y-4">
+          <Alert>
+            <Check className="w-4 h-4" />
+            <AlertDescription>
+              <span className="font-medium">{success}</span> message{success === 1 ? '' : 's'} upserted
+              {failed > 0 ? <>, <span className="font-medium text-destructive">{failed}</span> failed</> : null}.
+              Localization cache busted. Users may need to refresh their browsers.
+            </AlertDescription>
+          </Alert>
+          <div className="flex gap-2">
+            <Button onClick={() => navigate('/manage/localization')}>Back to Localization</Button>
+            <Button variant="outline" onClick={() => { setStep('landing'); setRows([]); setUploadedFile(null); setError(null); }}>
+              Import another file
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/resources/localization/LocalizationList.tsx
+++ b/src/resources/localization/LocalizationList.tsx
@@ -3,6 +3,7 @@ import { DigitList, DigitDatagrid } from '@/admin';
 import type { DigitColumn } from '@/admin';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useAvailableLocales, type LocaleOption } from '@/hooks/useAvailableLocales';
+import { LocalizationToolbar } from './LocalizationToolbar';
 
 const labelFor = (code: string, locales: LocaleOption[]) =>
   locales.find((o) => o.value === code)?.label ?? code;
@@ -87,7 +88,12 @@ function PivotDatagrid() {
 
 export function LocalizationList() {
   return (
-    <DigitList title="app.resources.localization" hasCreate sort={{ field: 'code', order: 'ASC' }}>
+    <DigitList
+      title="app.resources.localization"
+      hasCreate
+      sort={{ field: 'code', order: 'ASC' }}
+      actions={<LocalizationToolbar />}
+    >
       <LocaleSelector />
       <PivotDatagrid />
     </DigitList>

--- a/src/resources/localization/LocalizationToolbar.tsx
+++ b/src/resources/localization/LocalizationToolbar.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useListContext } from 'ra-core';
+import { Download, Upload, Loader2 } from 'lucide-react';
+import * as XLSX from 'xlsx';
+import { Button } from '@/components/ui/button';
+import { triggerDownload } from '@/admin/bulk/BulkImportPanel';
+import { localizationService } from '@/api';
+import { useApp } from '../../App';
+import { useAvailableLocales } from '@/hooks/useAvailableLocales';
+
+/** Two-button toolbar for the Localization list:
+ *  - Export downloads ALL messages for the two locales currently selected in
+ *    the pivot view (LocalizationList's locale dropdowns) as a flat .xlsx
+ *    with `code, module, locale, message` rows — same shape the bulk-import
+ *    page accepts so the round-trip is symmetric.
+ *  - Import navigates to /manage/localization/bulk.
+ *
+ *  We don't reuse `BulkExportButton` because the pivot list's data is
+ *  per-row (one row per code with two message columns), not what we want
+ *  for round-trip — we want one row per (code, locale) so users can edit
+ *  in Excel and re-upload without reshaping. */
+export function LocalizationToolbar() {
+  const { state } = useApp();
+  const tenantId = state.tenant;
+  const { filterValues } = useListContext();
+  const { locales, isLoading } = useAvailableLocales();
+
+  const fallbackA = locales[0]?.value ?? 'en_IN';
+  const fallbackB = locales[1]?.value ?? locales[0]?.value ?? 'en_IN';
+  const localeA = String(filterValues.locale || fallbackA);
+  const localeB = String(filterValues.locale2 || fallbackB);
+
+  const [exporting, setExporting] = useState(false);
+
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    try {
+      // De-dupe — selecting the same locale on both sides shouldn't double-fetch.
+      const distinctLocales = Array.from(new Set([localeA, localeB]));
+      const all = await Promise.all(
+        distinctLocales.map((loc) => localizationService.searchMessages(tenantId, loc)),
+      );
+      const flat = all.flat();
+      // Sort by (locale, module, code) so diffs across exports are clean.
+      flat.sort((a, b) =>
+        a.locale.localeCompare(b.locale) ||
+        a.module.localeCompare(b.module) ||
+        a.code.localeCompare(b.code),
+      );
+
+      const header = ['code', 'module', 'locale', 'message'];
+      const rows = flat.map((m) => [m.code, m.module, m.locale, m.message]);
+      const ws = XLSX.utils.aoa_to_sheet([header, ...rows]);
+      ws['!cols'] = [{ wch: 36 }, { wch: 22 }, { wch: 10 }, { wch: 80 }];
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, ws, 'Localization');
+      const buf = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+      const blob = new Blob([buf], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      });
+      const fname = `localization-${tenantId}-${distinctLocales.join('-')}.xlsx`;
+      triggerDownload(blob, fname);
+    } finally {
+      setExporting(false);
+    }
+  }, [tenantId, localeA, localeB]);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleExport}
+        disabled={exporting || isLoading}
+        className="gap-1.5"
+      >
+        {exporting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Download className="w-4 h-4" />}
+        {exporting ? 'Exporting…' : 'Export'}
+      </Button>
+      <Button asChild variant="outline" size="sm" className="gap-1.5">
+        <Link to="/manage/localization/bulk">
+          <Upload className="w-4 h-4" />
+          Bulk import
+        </Link>
+      </Button>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Two operator-friendly entry points on the Localization screen so a tenant's whole localization corpus can be edited in Excel and re-uploaded without touching the API directly.

### Export
New toolbar button on `/manage/localization` downloads an .xlsx with one row per `(code, module, locale)` for the **two locales currently selected in the pivot view's locale dropdowns**. Sorted by `(locale, module, code)` so cross-export diffs are clean.

The shape (`code, module, locale, message`) is identical to what the bulk-import page accepts, so the round-trip (export → edit → re-import) is symmetric.

### Bulk Import
New page at `/manage/localization/bulk` mirroring the existing Department / Designation / Employee bulk-import flow:

- **Template** with an Instructions sheet documenting the `code, module, locale, message` columns and the upsert semantics.
- **Validation** rejects rows whose locale isn't registered on the tenant (`common-masters.StateInfo[0].languages`). The localization service silently accepts them otherwise, leaving orphan rows the UI never reads.
- **Batched upsert** — rows are grouped by locale before upserting; `upsertMessages` (already batches at 500) is called once per locale. Avoids the per-row HTTP storm the generic `BulkImportPanel` would produce — a 3,000-row import becomes ~6 calls instead of 3,000.
- **Cache-bust** once at the end. Without this the localization service keeps serving the pre-write snapshot from its in-memory cache, and the digit-ui's localStorage cache picks up stale data on next refresh. Failure to bust is logged but doesn't fail the import.

### Service additions
- `LOCALIZATION_CACHE_BUST` endpoint added to `api/config.ts`.
- `localizationService.cacheBust()` — wraps `POST /localization/messages/cache-bust`. Available to any future code path that mutates localization.

## Test plan

- [x] `npx vite build --base=/configurator/` clean (5.09s, 1 chunk-size warning that pre-existed)
- [ ] Login as ke / ADMIN, navigate to `/manage/localization`
- [ ] **Export** — click Export, verify .xlsx downloads with both selected locales' rows, headers `code,module,locale,message`
- [ ] **Template** — `/manage/localization/bulk` → Download template → opens cleanly in Excel with example rows
- [ ] **Round-trip** — edit one row in the exported file, re-upload via bulk import, verify it shows up in the digit-ui after a hard refresh
- [ ] **Validation** — upload a file with an unregistered locale → preview marks the rows red with the right error
- [ ] **Cache bust** — verify the bumped message is reflected on `_search` immediately, not just after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk import localization data from Excel or CSV files with template generation, comprehensive validation, error reporting, and progress tracking
  * Export localization messages to Excel format with locale filtering and organization by module and code
  * Cache clearing following bulk updates to ensure consistent client-side data and search results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->