### PR TITLE
feat(tenant): editable helpline number + contact fields (CCRS#557)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import {
   DepartmentList, DepartmentShow, DepartmentEdit, DepartmentCreate, DepartmentBulkImport,
   DesignationList, DesignationShow, DesignationEdit, DesignationCreate, DesignationBulkImport,
   ComplaintTypeList, ComplaintTypeShow, ComplaintTypeEdit, ComplaintTypeCreate,
-  TenantList, TenantShow,
+  TenantList, TenantShow, TenantEdit,
   EmployeeList, EmployeeShow, EmployeeEdit, EmployeeCreate, EmployeeBulkImport,
   ComplaintList, ComplaintShow, ComplaintEdit, ComplaintCreate,
   BoundaryList, BoundaryShow, BoundaryEdit, BoundaryCreate,
@@ -111,7 +111,7 @@ function ManagementAdmin() {
     >
       <CoreAdminUI layout={DigitLayout} dashboard={DigitDashboard}>
         {/* Core entities with List/Show/Edit/Create */}
-        <Resource name="tenants" list={TenantList} show={TenantShow} />
+        <Resource name="tenants" list={TenantList} show={TenantShow} edit={TenantEdit} />
         <Resource name="departments" list={DepartmentList} show={DepartmentShow} edit={DepartmentEdit} create={DepartmentCreate} />
         <Resource name="designations" list={DesignationList} show={DesignationShow} edit={DesignationEdit} create={DesignationCreate} />
         <Resource name="complaint-types" list={ComplaintTypeList} show={ComplaintTypeShow} edit={ComplaintTypeEdit} create={ComplaintTypeCreate} />

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -14,6 +14,7 @@ export { ComplaintTypeEdit } from './complaint-types/ComplaintTypeEdit';
 export { ComplaintTypeCreate } from './complaint-types/ComplaintTypeCreate';
 export { TenantList } from './tenants/TenantList';
 export { TenantShow } from './tenants/TenantShow';
+export { TenantEdit } from './tenants/TenantEdit';
 export { EmployeeList } from './employees/EmployeeList';
 export { EmployeeShow } from './employees/EmployeeShow';
 export { EmployeeEdit } from './employees/EmployeeEdit';

--- a/src/resources/tenants/TenantEdit.tsx
+++ b/src/resources/tenants/TenantEdit.tsx
@@ -1,0 +1,32 @@
+import { DigitEdit, DigitFormInput, v } from '@/admin';
+
+export function TenantEdit() {
+  return (
+    <DigitEdit title="Edit Tenant">
+      <DigitFormInput source="code" label="Code" disabled />
+      <DigitFormInput source="name" label="Name" validate={v.name} />
+      <DigitFormInput
+        source="description"
+        label="Description"
+        help="Shown on the citizen home and the tenant picker."
+      />
+      <DigitFormInput
+        source="contactNumber"
+        label="Helpline number"
+        placeholder="e.g. 0800 720 999"
+        help="Surfaces as the citizen UI Helpline tile (tel: dial). Free text — supports short codes and spaces."
+      />
+      <DigitFormInput
+        source="emailId"
+        label="Email"
+        type="email"
+        validate={v.email}
+      />
+      <DigitFormInput
+        source="address"
+        label="Address"
+        help="Office address shown in the citizen footer / contact pages."
+      />
+    </DigitEdit>
+  );
+}

--- a/src/resources/tenants/TenantShow.tsx
+++ b/src/resources/tenants/TenantShow.tsx
@@ -7,6 +7,12 @@ function TenantDetail() {
   if (!record) return null;
 
   const city = record.city as Record<string, unknown> | undefined;
+  const dash = (val: unknown) => {
+    const s = typeof val === 'string' ? val.trim() : '';
+    return s
+      ? <Field>{s}</Field>
+      : <Field><span className="text-muted-foreground">—</span></Field>;
+  };
 
   return (
     <div className="space-y-3">
@@ -17,6 +23,22 @@ function TenantDetail() {
       <LabelFieldPair>
         <CardLabel>Name</CardLabel>
         <Field>{String(record.name ?? '')}</Field>
+      </LabelFieldPair>
+      <LabelFieldPair>
+        <CardLabel>Description</CardLabel>
+        {dash(record.description)}
+      </LabelFieldPair>
+      <LabelFieldPair>
+        <CardLabel>Helpline number</CardLabel>
+        {dash(record.contactNumber)}
+      </LabelFieldPair>
+      <LabelFieldPair>
+        <CardLabel>Email</CardLabel>
+        {dash(record.emailId)}
+      </LabelFieldPair>
+      <LabelFieldPair>
+        <CardLabel>Address</CardLabel>
+        {dash(record.address)}
       </LabelFieldPair>
       <LabelFieldPair>
         <CardLabel>City</CardLabel>
@@ -32,7 +54,7 @@ function TenantDetail() {
 
 export function TenantShow() {
   return (
-    <DigitShow title="Tenant Details">
+    <DigitShow title="Tenant Details" hasEdit>
       <TenantDetail />
     </DigitShow>
   );


### PR DESCRIPTION
## Summary
- The tenants page was list/show-only. The citizen UI Helpline tile (left menu on `/citizen/pgr-home`) is gated on the tenant's MDMS `contactNumber`; when it's blank, the row shows just "HELPLINE" with no dial. theflywheel/digit-ui-esbuild#101 wired the click-to-dial handler but couldn't render a number for `ke.nairobi` because that tenant has no `contactNumber` set. Gurjeet asked (egovernments/Citizen-Complaint-Resolution-System#557) for this to be editable from the configurator rather than one-off MDMS pokes.
- Adds `TenantEdit` (code disabled; `name` / `description` / `contactNumber` / `emailId` / `address` editable) and wires it on the `tenants` Resource.
- `TenantShow` gains an Edit button (`hasEdit`) and surfaces the same five fields with em-dash placeholders for missing values, so the current state is visible before/after edit.

## What's intentionally not touched
- Schema (`tenant.tenants`) and the data-provider update path are unchanged. The MDMS update flow re-fetches the record and merges only the form-supplied fields, so untouched bits (`city.*`, `OfficeTimings`, `logoId`, `imageId`, `domainUrl`) round-trip intact.
- `contactNumber` is free text (no regex). Kenyan helplines mix short codes, spaces, and country prefixes; the citizen UI just wraps the value in `tel:`.
- `city.*` stays read-only here — those values flow through the Phase 1/2 wizard and shouldn't get edited from the tenant card.

## Closes the loop on the live issue
With this merged + the configurator dist redeployed, the operational fix on naipepea is: navigate to `/configurator/manage/tenants/ke.nairobi` → Edit → set Helpline number → Save. The citizen `/digit-ui/citizen/pgr-home` Helpline tile then renders the value and dials it via the existing handler from digit-ui-esbuild#101.

## Test plan
- [ ] `npx vite build --base=/configurator/` succeeds (verified locally — 5.04s, 3,348 modules)
- [ ] Deploy dist to `naipepea` and navigate to `/configurator/manage/tenants` — list still renders, row click opens Show
- [ ] Show page renders all five new rows (em-dash for empty `contactNumber` on `ke.nairobi`) and exposes the Edit button
- [ ] Edit form loads with existing values, accepts a helpline number, saves successfully
- [ ] After save: `ke.nairobi` MDMS record has `contactNumber` populated; `city.*` and `OfficeTimings` unchanged (verify via DIGIT-MCP `mdms_search`)
- [ ] Citizen UI `/digit-ui/citizen/pgr-home` Helpline tile now shows the number and dials on click
- [ ] Round-trip for a tenant that already has `contactNumber` (e.g. `ke.testcity`) — no regression

## Related
- Issue: egovernments/Citizen-Complaint-Resolution-System#557
- Companion UI fix (already merged + deployed): theflywheel/digit-ui-esbuild#101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant editing capability in the admin interface with support for modifying tenant details including name, description, contact number, email, and address.
  * Enhanced tenant details view with additional information fields and improved display formatting for missing data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChakshuGautam/digit-configurator/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->