### PR TITLE
fix(onboarding): re-upload button now opens file picker (CCRS#563)

### DIFF
--- a/src/pages/Phase2Page.tsx
+++ b/src/pages/Phase2Page.tsx
@@ -133,6 +133,10 @@ export default function Phase2Page() {
 
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
+    // Reset so the same filename re-fires onChange on the next pick. Without
+    // this, after a failed validation the user fixes the workbook + re-picks
+    // the same file and nothing happens — the browser de-dupes the change.
+    e.target.value = '';
     if (!file) return;
 
     setError(null);
@@ -291,6 +295,19 @@ export default function Phase2Page() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
+      {/* Hidden file picker. Lives at page root so the "Re-upload Fixed File"
+          button in the `verify` step can trigger it — the dropzone (and the
+          original input) only exist while step === 'template', so on `verify`
+          the previous getElementById call would return null and silently
+          no-op (CCRS#563). */}
+      <input
+        id="boundary-file-upload"
+        type="file"
+        accept=".xlsx,.xls"
+        onChange={handleFileUpload}
+        className="hidden"
+        disabled={loading}
+      />
       {/* Header - DIGIT style */}
       <div className="flex items-center gap-2 sm:gap-3">
         <div className="w-10 h-10 sm:w-12 sm:h-12 bg-primary/10 border-2 border-primary rounded flex items-center justify-center flex-shrink-0">
@@ -568,14 +585,6 @@ export default function Phase2Page() {
                 <p className="text-xs text-muted-foreground">or click to browse</p>
               </>
             )}
-            <input
-              id="boundary-file-upload"
-              type="file"
-              accept=".xlsx,.xls"
-              onChange={handleFileUpload}
-              className="hidden"
-              disabled={loading}
-            />
           </div>
 
           <Alert variant="warning" className="mb-4 sm:mb-6">

--- a/src/pages/Phase4Page.tsx
+++ b/src/pages/Phase4Page.tsx
@@ -118,6 +118,10 @@ export default function Phase4Page() {
 
   const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
+    // Reset so the same filename re-fires onChange on the next pick. Without
+    // this, after a failed validation the user fixes the workbook + re-picks
+    // the same file and nothing happens — the browser de-dupes the change.
+    e.target.value = '';
     if (!file) return;
 
     setError(null);
@@ -339,6 +343,19 @@ export default function Phase4Page() {
 
   return (
     <div className="space-y-4 sm:space-y-6">
+      {/* Hidden file picker. Lives at page root so the "Re-upload Fixed File"
+          button in the `preview` step can trigger it — the dropzone (and the
+          original input) only exist while step === 'generate', so on `preview`
+          the previous getElementById call would return null and silently
+          no-op (CCRS#563). */}
+      <input
+        id="employee-file-upload"
+        type="file"
+        accept=".xlsx,.xls"
+        onChange={handleFileUpload}
+        className="hidden"
+        disabled={loading}
+      />
       {/* Header - DIGIT style */}
       <div className="flex items-center gap-2 sm:gap-3">
         <div className="w-10 h-10 sm:w-12 sm:h-12 bg-primary/10 border-2 border-primary rounded flex items-center justify-center flex-shrink-0">
@@ -506,14 +523,6 @@ export default function Phase4Page() {
                 <p className="text-xs text-muted-foreground">or click to browse</p>
               </>
             )}
-            <input
-              id="employee-file-upload"
-              type="file"
-              accept=".xlsx,.xls"
-              onChange={handleFileUpload}
-              className="hidden"
-              disabled={loading}
-            />
           </div>
 
           <div className="flex flex-col sm:flex-row justify-between gap-3 sm:gap-0">


### PR DESCRIPTION
## Summary
- Phase 2 (Boundary) and Phase 4 (Employee) onboarding both hosted the hidden `<input type=\"file\">` *inside* the dropzone div, which itself only renders while `step === 'template'` / `step === 'generate'`. The "Re-upload Fixed File" button renders in the *next* step (`verify` / `preview`), where the input has already unmounted — `document.getElementById('boundary-file-upload')?.click()` returned `null`, the optional chain swallowed it, and the OS file dialog never opened. CCRS#563.
- Fix: lift the hidden `<input>` to the page root so it stays mounted across all steps. The existing dropzone click handler still finds it by id (no caller changes), and the re-upload button now actually triggers the picker.
- Also: reset `e.target.value = ''` at the top of `handleFileUpload`. After a failed validation the user typically fixes the workbook and re-picks the same filename; without the reset, the browser de-dupes the change event and `onChange` doesn't fire.

## Files
- `src/pages/Phase2Page.tsx` — Boundary upload
- `src/pages/Phase4Page.tsx` — Employee upload

## Test plan
- [ ] Phase 2: download boundary template, fill with a deliberate error (e.g. duplicate code), upload, land on the verify step with errors → click "Re-upload Fixed File" → OS file picker opens
- [ ] Same flow, but re-pick the *exact same filename* a second time → `onChange` still fires (parses again)
- [ ] Happy-path dropzone click on the template step still opens the picker (regression check on the original entry point)
- [ ] Repeat all three for Phase 4 employee upload
- [ ] No new lint errors in either file (pre-existing `fetchHierarchies` / `fetchReferenceData` hoisting errors are untouched)

## Related
- Issue: egovernments/Citizen-Complaint-Resolution-System#563
- The companion observation about `e.target.value` reset isn't in the issue, but it's the same class of bug — the user reports "dialog not opening" on the *first* re-upload, and would have hit "dialog opens but nothing happens" on the *second* without the reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)