### PR TITLE
fix: CCRS#483 follow-up — list active chip + complaint-type edit active

### DIFF
--- a/src/admin/schemaUtils.ts
+++ b/src/admin/schemaUtils.ts
@@ -6,6 +6,7 @@ import {
   type DigitColumn,
 } from '@digit-ui/datagrid';
 import { EntityLink } from '@/components/ui/EntityLink';
+import { StatusChip } from '@/admin/fields';
 
 // Re-export types and pure functions from the package
 export {
@@ -26,14 +27,54 @@ export type {
 
 /**
  * App-level wrapper for generateColumns that auto-injects EntityLink
- * as the renderRef callback. The package version uses a callback pattern;
- * this wrapper preserves the original 2-arg API for backward compatibility.
+ * as the renderRef callback, and overrides boolean column rendering
+ * with a `StatusChip` so list pages show the value at a glance.
+ *
+ * Why the override: the package's default boolean rendering puts the
+ * column into inline-edit mode, which renders just a bare `<Switch>`
+ * toggle with no text label. On the Gender Types list page (and any
+ * other generic master with an `active: boolean` field) operators
+ * couldn't tell which rows were enabled without opening each one
+ * (egovernments/CCRS#483 follow-up — Gurjeet flagged it on the
+ * Gender Types list specifically). Replacing the inline toggle with
+ * a `StatusChip` ("Active"/"Inactive" or "Yes"/"No") makes the state
+ * legible. Inline-editing is dropped on the list page for boolean
+ * cells; users edit through the row's dedicated Edit form, which
+ * Chakshu's #46 fix already wired up correctly.
  */
+function withStatusChipForBooleans(columns: DigitColumn[]): DigitColumn[] {
+  return columns.map((col) => {
+    const isBoolean =
+      typeof col.editable === 'object' && col.editable?.type === 'boolean';
+    if (!isBoolean || col.render) return col;
+    // Pick a tighter label for the canonical "active" / "isActive" flag;
+    // fall back to Yes/No for any other boolean field so the chip stays
+    // readable for non-status flags.
+    const isActiveField =
+      col.source === 'active' || col.source === 'isActive';
+    const labels = isActiveField
+      ? { true: 'Active', false: 'Inactive' }
+      : { true: 'Yes', false: 'No' };
+    return {
+      ...col,
+      // Drop inline-editable so the chip is shown instead of the bare
+      // toggle. The Edit page remains the canonical way to flip the flag.
+      editable: undefined,
+      render: (record) =>
+        React.createElement(StatusChip, {
+          value: (record as Record<string, unknown>)[col.source],
+          labels,
+        }),
+    };
+  });
+}
+
 export function generateColumns(
   schema: SchemaDefinition,
   refMap: Record<string, RefMapEntry>
 ): DigitColumn[] {
-  return baseGenerateColumns(schema, refMap, (resource, id) =>
+  const base = baseGenerateColumns(schema, refMap, (resource, id) =>
     React.createElement(EntityLink, { resource, id })
   );
+  return withStatusChipForBooleans(base);
 }

--- a/src/resources/complaint-types/ComplaintTypeEdit.tsx
+++ b/src/resources/complaint-types/ComplaintTypeEdit.tsx
@@ -1,5 +1,6 @@
 import { DigitEdit, DigitFormInput, DigitFormSelect, v } from '@/admin';
 import { FieldSection } from '@/admin/fields';
+import { BooleanInput } from '@/admin/widgets';
 
 export function ComplaintTypeEdit() {
   return (
@@ -17,6 +18,16 @@ export function ComplaintTypeEdit() {
           <DigitFormInput source="slaHours" label="SLA (hours)" type="number" validate={v.slaHours} />
           <DigitFormInput source="menuPath" label="Menu Path" />
           <DigitFormInput source="keywords" label="Keywords" />
+          {/* The active flag was previously omitted from this dedicated
+              edit form, so operators had no way to enable/disable a
+              complaint type — `ComplaintTypeList` rendered a Status
+              column for it but offered no editing affordance (closes
+              the second item in egovernments/CCRS#483 follow-up).
+              The `BooleanInput` widget keeps the form value as a real
+              boolean so the MDMS update doesn't reject with
+              "expected type: Boolean, found: String" — same fix
+              Chakshu shipped for the generic edit path in #46. */}
+          <BooleanInput source="active" label="Active" />
         </div>
       </FieldSection>
     </DigitEdit>


### PR DESCRIPTION
Two follow-ups to [#46](https://github.com/ChakshuGautam/digit-configurator/pull/46) (the boolean Edit-field fix). Both flagged by Gurjeet on [egovernments/CCRS#483](https://github.com/egovernments/Citizen-Complaint-Resolution-System/issues/483#issuecomment-) after the original fix landed.

## Summary

**1. Generic list page boolean cells were unreadable.**
`generateColumns` set every boolean property to `editable: { type: 'boolean' }`, so `DigitDatagrid` rendered the cell as a bare `<Switch>` — no text, no label, no chip. On the Gender Types list page that meant the "Active" column showed only a tiny toggle, which Gurjeet read as "does not display value if its enabled or disabled."

Fix in `src/admin/schemaUtils.ts`: post-process the schema-generated columns. For boolean fields, drop inline-edit and attach a `StatusChip` render — "Active" / "Inactive" for fields named `active` / `isActive`, "Yes" / "No" for any other boolean. The row's Edit page remains the canonical way to flip the flag (which #46 already wired up correctly via `MdmsResourceEdit`). Same pattern `ComplaintTypeList` was already using directly.

**2. Complaint Type Edit had no field for the Active flag at all.**
`ComplaintTypeList.tsx` rendered a Status column for `active`, but `ComplaintTypeEdit.tsx` only exposed `serviceCode` / `name` / `department` / `slaHours` / `menuPath` / `keywords`. So operators could *see* whether a complaint type was active on the list but had no way to *toggle* it. Add `<BooleanInput source="active" label="Active" />` (the same widget #46 uses).

## What changed

- `src/admin/schemaUtils.ts` — wraps `baseGenerateColumns` to post-process boolean columns into `StatusChip` renders.
- `src/resources/complaint-types/ComplaintTypeEdit.tsx` — adds the Active checkbox to the form.

55 insertions, 3 deletions across 2 files.

## Test plan

Verified locally against naipepea Kong via vite at :5173:

- [x] `/configurator/manage/gender-types` shows `Code | Active` columns. All four rows (`MALE`, `FEMALE`, `TRANSGENDER` as **Active**; `OTHERS` as **Inactive**) render with the chip text.
- [x] `/configurator/manage/complaint-types/ContractDispute/edit` renders the **Active** checkbox bound to the record's `active` boolean (checked = `true` for that record).
- [ ] Round-trip save for both pages (relies on the same `BooleanInput` widget you shipped in #46, so should just work).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to enable or disable complaint types directly in the dedicated complaint type edit form
  * Enhanced boolean field rendering in data grid columns to display status indicators instead of inline edit toggles, improving readability and consistency across the interface

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChakshuGautam/digit-configurator/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->