### PR TITLE
fix(employees): mobile asterisk + DOB-in-past + appointment date required (CCRS#484)

### DIFF
--- a/src/admin/hrms/useMobileValidator.ts
+++ b/src/admin/hrms/useMobileValidator.ts
@@ -80,7 +80,7 @@ export function useMobileValidator(): UseMobileValidatorResult {
     } catch {
       compiled = null;
     }
-    return (value: unknown) => {
+    const fn: Validator = (value: unknown) => {
       if (value === undefined || value === null || value === '') {
         return 'Required';
       }
@@ -93,6 +93,14 @@ export function useMobileValidator(): UseMobileValidatorResult {
       }
       return undefined;
     };
+    // ra-core `useInput` exposes `isRequired` based on a flag on the
+    // validator function — without it the field gets no "*" mark in
+    // DigitFormInput. The mobile validator is built dynamically (rules
+    // come from MDMS) so we can't compose with `required` upfront via
+    // validation.ts's flagRequired; tag the dynamic result here instead.
+    // Closes the missing-asterisk point on egovernments/CCRS#484.
+    (fn as unknown as { isRequired?: boolean }).isRequired = true;
+    return fn;
   }, [rules]);
 
   return { rules, validator, isLoading };

--- a/src/admin/validation.ts
+++ b/src/admin/validation.ts
@@ -103,6 +103,37 @@ export const slaHours = composeValidators(
   maxValue(8760),
 );
 
+/**
+ * Date strictly in the past — used for Date of Birth where today's date
+ * is nonsensical. Accepts ISO strings from `<input type="date">` (e.g.
+ * "2026-05-12"), epoch numbers, and Date instances. Empty values pass
+ * (compose with `required` to also require a value).
+ *
+ * Closes the "DOB accepts today" point on egovernments/CCRS#484.
+ */
+export const dateInPast = (value: unknown) => {
+  if (value === undefined || value === null || value === '') return undefined;
+  let ms: number;
+  if (typeof value === 'number') {
+    ms = value;
+  } else if (value instanceof Date) {
+    ms = value.getTime();
+  } else if (typeof value === 'string') {
+    ms = new Date(value).getTime();
+  } else {
+    return 'Enter a valid date';
+  }
+  if (Number.isNaN(ms)) return 'Enter a valid date';
+  const now = new Date();
+  // Strict comparison at day granularity — today's midnight onward is rejected.
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  if (ms >= todayStart) return 'Date must be in the past';
+  return undefined;
+};
+
+/** Date of Birth — required and strictly before today. */
+export const dobRequired = composeValidators(required, dateInPast);
+
 // Re-export composeValidators for custom combos
 export { composeValidators };
 
@@ -123,3 +154,4 @@ flagRequired(emailRequired);
 flagRequired(codeRequired);
 flagRequired(positiveInt);
 flagRequired(slaHours);
+flagRequired(dobRequired);

--- a/src/admin/validation.ts
+++ b/src/admin/validation.ts
@@ -119,7 +119,20 @@ export const dateInPast = (value: unknown) => {
   } else if (value instanceof Date) {
     ms = value.getTime();
   } else if (typeof value === 'string') {
-    ms = new Date(value).getTime();
+    // `<input type="date">` ships "YYYY-MM-DD". `new Date("YYYY-MM-DD")` parses
+    // as UTC midnight, while our comparison anchor (`todayStart` below) is
+    // local midnight — in negative-UTC-offset tenants that mismatch lets
+    // today's date sneak through as "before today". Parse the date-only form
+    // as local-midnight so the comparison stays apples-to-apples regardless
+    // of TZ. Fall back to native parsing for fully-qualified strings
+    // (timestamps with a Z / ±HH:MM offset, RFC2822, etc.).
+    const isoDateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (isoDateOnly) {
+      const [, y, m, d] = isoDateOnly;
+      ms = new Date(Number(y), Number(m) - 1, Number(d)).getTime();
+    } else {
+      ms = new Date(value).getTime();
+    }
   } else {
     return 'Enter a valid date';
   }

--- a/src/resources/employees/EmployeeCreate.tsx
+++ b/src/resources/employees/EmployeeCreate.tsx
@@ -121,14 +121,14 @@ export function EmployeeCreate() {
             help={mobileRules.errorMessage}
           />
           <DigitFormInput source="user.emailId" label="Email" type="email" validate={v.emailOptional} />
-          <DigitFormInput source="user.dob" label="Date of Birth" type="date" validate={v.required} />
+          <DigitFormInput source="user.dob" label="Date of Birth" type="date" validate={v.dobRequired} />
           <DigitFormSelect
             source="user.gender"
             label="Gender"
             choices={GENDER_CHOICES}
             placeholder="Select gender..."
           />
-          <DigitFormInput source="dateOfAppointment" label="Date of Appointment" type="date" />
+          <DigitFormInput source="dateOfAppointment" label="Date of Appointment" type="date" validate={v.required} />
           <DigitFormSelect
             source="employeeStatus"
             label="Employee Status"


### PR DESCRIPTION
## Summary
Picks off three of Gurjeet's review items on egovernments/CCRS#484 (Configurator → Create Employee):

1. **Mobile field had no required asterisk.** `useMobileValidator` builds its validator dynamically from MDMS rules, so `validation.ts`'s static \`flagRequired\` chain never tagged it. Tagged the memo'd function with \`.isRequired = true\` after construction so \`DigitFormInput\` surfaces the "*" mark like every other required field on the form.
2. **Date of Birth accepted today's date.** Added \`v.dateInPast\` (and composed \`v.dobRequired = required + dateInPast\`) — rejects any value at today's midnight or later. Accepts ISO strings, epoch ms, or Date instances so it works for both \`<input type="date">\` and already-coerced form state.
3. **Date of Appointment was optional, then the transform stamped \`Date.now()\`** if the user left it blank — masking the requirement and producing the downstream "Employee period of assignment cannot be before date of appointment" error reported on the issue. Wired \`validate={v.required}\` onto the field so submission is blocked at the form layer.

## Deferred (intentionally out of scope)
- **"Login with newly-created user with default password fails"** — same symptom family as the existing \`ke.nairobi\` stale-encryption-key thread; tracked separately, not a form bug.
- **"Mobile validation triggers on correct input"** — I couldn't reproduce this on a fresh form after the asterisk fix landed (the perceived error may have been the help-text style being mistaken for an error). Will revisit if Gurjeet can still repro post-merge.

## Test plan
- [ ] Create Employee form on naipepea configurator shows a red \`*\` next to **Mobile Number**.
- [ ] DOB picker accepts yesterday but rejects today's date with "Date must be in the past".
- [ ] Submitting with **Date of Appointment** empty now shows a "This field is required" error instead of silently saving with today's date.
- [ ] \`npx tsc --noEmit\` clean.

Refs: #484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed required-field indicators so date and mobile inputs correctly show the “*” when validation marks them required.

* **New Features**
  - Enforced that date of birth must be strictly before today.
  - Employee creation now requires appointment date to be provided.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChakshuGautam/digit-configurator/pull/61)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->