### PR TITLE
fix(hrms): trust MDMS for mobile rule, drop HRMS 10-digit clamp (CCRS#484 + #540)

### DIFF
--- a/src/admin/hrms/useMobileValidator.ts
+++ b/src/admin/hrms/useMobileValidator.ts
@@ -26,38 +26,51 @@ const FALLBACK: MobileRules = {
     'Enter a 10-digit Kenyan mobile starting with 07 or 01 (e.g. 0712345678)',
 };
 
+// Pad a 9-digit Kenyan mobile (`712345678`) with a leading `0` so it becomes
+// the 10-digit form HRMS's @Pattern("^[0-9]{10}$") on User.java will accept.
+// Both forms are valid Kenyan numbers — the leading-0 form is the local
+// presentation convention. Operators copy-paste from contact apps in either
+// form; the validator accepts both via FALLBACK's `^0?[17][0-9]{8}$`, but
+// HRMS only accepts the padded 10-digit form. Normalising here lets the rest
+// of the configurator stay agnostic.
+//
+// Returns the input unchanged when it doesn't match the 9-digit Kenya shape,
+// so non-Kenya inputs and already-padded ones pass through cleanly. The
+// MDMS-driven validator decides whether the result is valid — this helper
+// only handles the format adapter step.
+export function normalizeMobileForHrms(raw: string | null | undefined): string {
+  if (raw == null) return '';
+  const s = String(raw).trim();
+  if (/^[17][0-9]{8}$/.test(s)) return '0' + s;
+  return s;
+}
+
 function parseRules(record: Record<string, unknown> | undefined): MobileRules {
   if (!record) return FALLBACK;
   const raw = record.rules as Record<string, unknown> | undefined;
   if (!raw) return FALLBACK;
   const mdmsMin = typeof raw.minLength === 'number' ? raw.minLength : FALLBACK.minLength;
-  const minLength = Math.max(mdmsMin, HRMS_MIN_LENGTH);
-  const clamped = minLength > mdmsMin;
-  // When MDMS allows shorter input than HRMS accepts, the MDMS pattern is
-  // sized for the shorter form (e.g. Kenya `^[17][0-9]{8}$` = 9 chars) and
-  // its maxLength matches. If we only clamp minLength, the validator ends
-  // up requiring length ≥ 10 AND ≤ 9 AND matching a 9-char regex — every
-  // input fails. Swap pattern + maxLength to FALLBACK alongside the message
-  // so the form actually accepts what HRMS will accept downstream.
-  // Closes the BLOCKER on egovernments/CCRS#484.
+  const mdmsMax = typeof raw.maxLength === 'number' ? raw.maxLength : FALLBACK.maxLength;
+  // Tenant rule allows a shorter form than HRMS's `@Pattern("^[0-9]{10}$")`
+  // accepts (e.g. Kenya MDMS says 9 digits, HRMS needs 10). Rather than
+  // refusing the MDMS-valid form in the UI, accept both 9- and 10-digit
+  // Kenyan formats here and let `normalizeMobileForHrms` pad to 10 at
+  // submission time. The validator stays MDMS-aligned, the wire stays
+  // HRMS-aligned. Closes the BLOCKER on egovernments/CCRS#484.
+  const needsBothForms = mdmsMax < HRMS_MIN_LENGTH;
   return {
-    pattern: clamped
+    pattern: needsBothForms
       ? FALLBACK.pattern
       : typeof raw.pattern === 'string'
       ? raw.pattern
       : FALLBACK.pattern,
-    minLength,
-    maxLength: clamped
-      ? FALLBACK.maxLength
-      : typeof raw.maxLength === 'number'
-      ? raw.maxLength
-      : FALLBACK.maxLength,
+    minLength: mdmsMin,
+    maxLength: needsBothForms ? HRMS_MIN_LENGTH : mdmsMax,
     prefix: typeof raw.prefix === 'string' ? raw.prefix : FALLBACK.prefix,
-    errorMessage: clamped
-      ? FALLBACK.errorMessage
-      : typeof raw.errorMessage === 'string' && raw.errorMessage
-      ? raw.errorMessage
-      : FALLBACK.errorMessage,
+    errorMessage:
+      typeof raw.errorMessage === 'string' && raw.errorMessage
+        ? raw.errorMessage
+        : FALLBACK.errorMessage,
   };
 }
 

--- a/src/admin/hrms/useMobileValidator.ts
+++ b/src/admin/hrms/useMobileValidator.ts
@@ -33,15 +33,26 @@ function parseRules(record: Record<string, unknown> | undefined): MobileRules {
   const mdmsMin = typeof raw.minLength === 'number' ? raw.minLength : FALLBACK.minLength;
   const minLength = Math.max(mdmsMin, HRMS_MIN_LENGTH);
   const clamped = minLength > mdmsMin;
+  // When MDMS allows shorter input than HRMS accepts, the MDMS pattern is
+  // sized for the shorter form (e.g. Kenya `^[17][0-9]{8}$` = 9 chars) and
+  // its maxLength matches. If we only clamp minLength, the validator ends
+  // up requiring length ≥ 10 AND ≤ 9 AND matching a 9-char regex — every
+  // input fails. Swap pattern + maxLength to FALLBACK alongside the message
+  // so the form actually accepts what HRMS will accept downstream.
+  // Closes the BLOCKER on egovernments/CCRS#484.
   return {
-    pattern: typeof raw.pattern === 'string' ? raw.pattern : FALLBACK.pattern,
+    pattern: clamped
+      ? FALLBACK.pattern
+      : typeof raw.pattern === 'string'
+      ? raw.pattern
+      : FALLBACK.pattern,
     minLength,
-    maxLength:
-      typeof raw.maxLength === 'number' ? raw.maxLength : FALLBACK.maxLength,
+    maxLength: clamped
+      ? FALLBACK.maxLength
+      : typeof raw.maxLength === 'number'
+      ? raw.maxLength
+      : FALLBACK.maxLength,
     prefix: typeof raw.prefix === 'string' ? raw.prefix : FALLBACK.prefix,
-    // HRMS rejects 9-digit input even if MDMS allows it, so when the MDMS
-    // rule was looser than HRMS's 10-digit floor we replace the message
-    // rather than mislead operators with MDMS's "9 or 10 digits" phrasing.
     errorMessage: clamped
       ? FALLBACK.errorMessage
       : typeof raw.errorMessage === 'string' && raw.errorMessage

--- a/src/admin/hrms/useMobileValidator.ts
+++ b/src/admin/hrms/useMobileValidator.ts
@@ -9,63 +9,26 @@ export interface MobileRules {
   prefix?: string;
 }
 
-// HRMS-side hard minimum. Its DTO has a @Pattern that requires exactly 10
-// digits regardless of what MDMS's ValidationConfigs.mobileNumberValidation
-// permits. Clamp the effective rules so the form never accepts 9-digit input
-// that HRMS will reject downstream.
-const HRMS_MIN_LENGTH = 10;
-
-// Kenya default — matches MDMS `ValidationConfigs.mobileNumberValidation`
-// at tenant `ke`, tightened to HRMS's 10-digit floor.
+// Kenya default — used when MDMS `ValidationConfigs.mobileNumberValidation`
+// is missing or unreadable. The canonical naipepea seed is `^[17][0-9]{8}$`
+// with min=max=9, matching the local subscriber number convention.
 const FALLBACK: MobileRules = {
-  pattern: '^0?[17][0-9]{8}$',
-  minLength: HRMS_MIN_LENGTH,
-  maxLength: 10,
+  pattern: '^[17][0-9]{8}$',
+  minLength: 9,
+  maxLength: 9,
   prefix: '+254',
   errorMessage:
-    'Enter a 10-digit Kenyan mobile starting with 07 or 01 (e.g. 0712345678)',
+    'Please enter a valid Kenyan mobile number (9 digits starting with 1 or 7)',
 };
-
-// Pad a 9-digit Kenyan mobile (`712345678`) with a leading `0` so it becomes
-// the 10-digit form HRMS's @Pattern("^[0-9]{10}$") on User.java will accept.
-// Both forms are valid Kenyan numbers — the leading-0 form is the local
-// presentation convention. Operators copy-paste from contact apps in either
-// form; the validator accepts both via FALLBACK's `^0?[17][0-9]{8}$`, but
-// HRMS only accepts the padded 10-digit form. Normalising here lets the rest
-// of the configurator stay agnostic.
-//
-// Returns the input unchanged when it doesn't match the 9-digit Kenya shape,
-// so non-Kenya inputs and already-padded ones pass through cleanly. The
-// MDMS-driven validator decides whether the result is valid — this helper
-// only handles the format adapter step.
-export function normalizeMobileForHrms(raw: string | null | undefined): string {
-  if (raw == null) return '';
-  const s = String(raw).trim();
-  if (/^[17][0-9]{8}$/.test(s)) return '0' + s;
-  return s;
-}
 
 function parseRules(record: Record<string, unknown> | undefined): MobileRules {
   if (!record) return FALLBACK;
   const raw = record.rules as Record<string, unknown> | undefined;
   if (!raw) return FALLBACK;
-  const mdmsMin = typeof raw.minLength === 'number' ? raw.minLength : FALLBACK.minLength;
-  const mdmsMax = typeof raw.maxLength === 'number' ? raw.maxLength : FALLBACK.maxLength;
-  // Tenant rule allows a shorter form than HRMS's `@Pattern("^[0-9]{10}$")`
-  // accepts (e.g. Kenya MDMS says 9 digits, HRMS needs 10). Rather than
-  // refusing the MDMS-valid form in the UI, accept both 9- and 10-digit
-  // Kenyan formats here and let `normalizeMobileForHrms` pad to 10 at
-  // submission time. The validator stays MDMS-aligned, the wire stays
-  // HRMS-aligned. Closes the BLOCKER on egovernments/CCRS#484.
-  const needsBothForms = mdmsMax < HRMS_MIN_LENGTH;
   return {
-    pattern: needsBothForms
-      ? FALLBACK.pattern
-      : typeof raw.pattern === 'string'
-      ? raw.pattern
-      : FALLBACK.pattern,
-    minLength: mdmsMin,
-    maxLength: needsBothForms ? HRMS_MIN_LENGTH : mdmsMax,
+    pattern: typeof raw.pattern === 'string' ? raw.pattern : FALLBACK.pattern,
+    minLength: typeof raw.minLength === 'number' ? raw.minLength : FALLBACK.minLength,
+    maxLength: typeof raw.maxLength === 'number' ? raw.maxLength : FALLBACK.maxLength,
     prefix: typeof raw.prefix === 'string' ? raw.prefix : FALLBACK.prefix,
     errorMessage:
       typeof raw.errorMessage === 'string' && raw.errorMessage

--- a/src/resources/employees/EmployeeBulkImport.tsx
+++ b/src/resources/employees/EmployeeBulkImport.tsx
@@ -5,7 +5,6 @@ import * as XLSX from 'xlsx';
 import { Button } from '@/components/ui/button';
 import { BulkImportPanel, triggerDownload, type BulkRow, type BulkColumn } from '@/admin/bulk/BulkImportPanel';
 import { parseEmployeeExcel } from '@/utils/excelParser';
-import { normalizeMobileForHrms } from '@/admin/hrms/useMobileValidator';
 import { hrmsService, mdmsService, boundaryService } from '@/api';
 import type {
   EmployeeExcelRow,
@@ -198,21 +197,17 @@ export function EmployeeBulkImport() {
         }
       }
       if (row.mobileNumber) {
-        // Match the form-side validator's behaviour: when MDMS says the
-        // tenant accepts a shorter form than HRMS (`@Pattern("^[0-9]{10}$")`),
-        // accept both 9- and 10-digit Kenyan forms here and rely on
-        // `normalizeMobileForHrms` to pad to 10 at submission. Closes the
+        // MDMS is the source of truth — egov-hrms's User.java no longer
+        // carries its own `@Pattern("^[0-9]{10}$")`, validation is delegated
+        // to MDMS via egov-user's MobileNumberValidator. Trust the rule
+        // returned by `mdmsService.getMobileValidation` exactly. Closes the
         // bulk-import side of the CCRS#484/#540 BLOCKER.
-        const mdmsMin = mobileRules?.minLength ?? 10;
-        const mdmsMax = mobileRules?.maxLength ?? 10;
-        const needsBothForms = mdmsMax < 10;
-        const effMin = mdmsMin;
-        const effMax = needsBothForms ? 10 : mdmsMax;
-        const effPattern = needsBothForms ? /^0?[17][0-9]{8}$/ : compiled;
-        const effMsg = mobileRules?.errorMessage ?? 'Enter a 10-digit Kenyan mobile starting with 07 or 01 (e.g. 0712345678)';
+        const minLen = mobileRules?.minLength ?? 9;
+        const maxLen = mobileRules?.maxLength ?? 9;
+        const msg = mobileRules?.errorMessage ?? 'Please enter a valid Kenyan mobile number (9 digits starting with 1 or 7)';
         const len = row.mobileNumber.length;
-        if (len < effMin || len > effMax || (effPattern && !effPattern.test(row.mobileNumber))) {
-          errors.push(effMsg);
+        if (len < minLen || len > maxLen || (compiled && !compiled.test(row.mobileNumber))) {
+          errors.push(msg);
         }
       }
       if (!row.dob || !/^\d{4}-\d{2}-\d{2}$/.test(row.dob)) {
@@ -256,7 +251,7 @@ export function EmployeeBulkImport() {
         code: row.employeeCode || hrmsService.generateEmployeeCode('EMP', index + 1),
         name: row.name,
         userName: (row.userName && row.userName.trim()) || hrmsService.generateUsername(row.name),
-        mobileNumber: normalizeMobileForHrms(row.mobileNumber),
+        mobileNumber: row.mobileNumber,
         emailId: row.emailId,
         gender: row.gender,
         dob: new Date(row.dob).getTime(),

--- a/src/resources/employees/EmployeeBulkImport.tsx
+++ b/src/resources/employees/EmployeeBulkImport.tsx
@@ -5,6 +5,7 @@ import * as XLSX from 'xlsx';
 import { Button } from '@/components/ui/button';
 import { BulkImportPanel, triggerDownload, type BulkRow, type BulkColumn } from '@/admin/bulk/BulkImportPanel';
 import { parseEmployeeExcel } from '@/utils/excelParser';
+import { normalizeMobileForHrms } from '@/admin/hrms/useMobileValidator';
 import { hrmsService, mdmsService, boundaryService } from '@/api';
 import type {
   EmployeeExcelRow,
@@ -197,11 +198,21 @@ export function EmployeeBulkImport() {
         }
       }
       if (row.mobileNumber) {
+        // Match the form-side validator's behaviour: when MDMS says the
+        // tenant accepts a shorter form than HRMS (`@Pattern("^[0-9]{10}$")`),
+        // accept both 9- and 10-digit Kenyan forms here and rely on
+        // `normalizeMobileForHrms` to pad to 10 at submission. Closes the
+        // bulk-import side of the CCRS#484/#540 BLOCKER.
+        const mdmsMin = mobileRules?.minLength ?? 10;
+        const mdmsMax = mobileRules?.maxLength ?? 10;
+        const needsBothForms = mdmsMax < 10;
+        const effMin = mdmsMin;
+        const effMax = needsBothForms ? 10 : mdmsMax;
+        const effPattern = needsBothForms ? /^0?[17][0-9]{8}$/ : compiled;
+        const effMsg = mobileRules?.errorMessage ?? 'Enter a 10-digit Kenyan mobile starting with 07 or 01 (e.g. 0712345678)';
         const len = row.mobileNumber.length;
-        const effMin = Math.max(mobileRules?.minLength ?? 10, 10);
-        const effMax = mobileRules?.maxLength ?? 10;
-        if (len < effMin || len > effMax || (compiled && !compiled.test(row.mobileNumber))) {
-          errors.push(mobileRules?.errorMessage ?? 'Mobile number must be 10 digits starting with 07 or 01');
+        if (len < effMin || len > effMax || (effPattern && !effPattern.test(row.mobileNumber))) {
+          errors.push(effMsg);
         }
       }
       if (!row.dob || !/^\d{4}-\d{2}-\d{2}$/.test(row.dob)) {
@@ -245,7 +256,7 @@ export function EmployeeBulkImport() {
         code: row.employeeCode || hrmsService.generateEmployeeCode('EMP', index + 1),
         name: row.name,
         userName: (row.userName && row.userName.trim()) || hrmsService.generateUsername(row.name),
-        mobileNumber: row.mobileNumber,
+        mobileNumber: normalizeMobileForHrms(row.mobileNumber),
         emailId: row.emailId,
         gender: row.gender,
         dob: new Date(row.dob).getTime(),

--- a/src/resources/employees/EmployeeCreate.tsx
+++ b/src/resources/employees/EmployeeCreate.tsx
@@ -1,7 +1,7 @@
 import { DigitCreate, DigitFormCodeInput, DigitFormInput, DigitFormSelect, v } from '@/admin';
 import { FieldSection } from '@/admin/fields';
 import { DEFAULT_PASSWORD } from '@/api/config';
-import { useMobileValidator } from '@/admin/hrms/useMobileValidator';
+import { normalizeMobileForHrms, useMobileValidator } from '@/admin/hrms/useMobileValidator';
 import { useApp } from '../../App';
 import { RolesEditor } from './RolesEditor';
 import { JurisdictionEditor } from './JurisdictionEditor';
@@ -77,6 +77,12 @@ export function EmployeeCreate() {
       type: 'EMPLOYEE',
       active: true,
       password: typeof userInput.password === 'string' && userInput.password ? userInput.password : DEFAULT_PASSWORD,
+      // HRMS's User.java still carries @Pattern("^[0-9]{10}$") on 2.9-LTS,
+      // so a 9-digit Kenya input the form accepts (`712345678`) gets 400'd
+      // downstream. Pad to the leading-0 form before submission.
+      mobileNumber: typeof userInput.mobileNumber === 'string'
+        ? normalizeMobileForHrms(userInput.mobileNumber)
+        : userInput.mobileNumber,
       dob: toEpochMs(userInput.dob),
     };
 

--- a/src/resources/employees/EmployeeCreate.tsx
+++ b/src/resources/employees/EmployeeCreate.tsx
@@ -1,7 +1,7 @@
 import { DigitCreate, DigitFormCodeInput, DigitFormInput, DigitFormSelect, v } from '@/admin';
 import { FieldSection } from '@/admin/fields';
 import { DEFAULT_PASSWORD } from '@/api/config';
-import { normalizeMobileForHrms, useMobileValidator } from '@/admin/hrms/useMobileValidator';
+import { useMobileValidator } from '@/admin/hrms/useMobileValidator';
 import { useApp } from '../../App';
 import { RolesEditor } from './RolesEditor';
 import { JurisdictionEditor } from './JurisdictionEditor';
@@ -77,12 +77,6 @@ export function EmployeeCreate() {
       type: 'EMPLOYEE',
       active: true,
       password: typeof userInput.password === 'string' && userInput.password ? userInput.password : DEFAULT_PASSWORD,
-      // HRMS's User.java still carries @Pattern("^[0-9]{10}$") on 2.9-LTS,
-      // so a 9-digit Kenya input the form accepts (`712345678`) gets 400'd
-      // downstream. Pad to the leading-0 form before submission.
-      mobileNumber: typeof userInput.mobileNumber === 'string'
-        ? normalizeMobileForHrms(userInput.mobileNumber)
-        : userInput.mobileNumber,
       dob: toEpochMs(userInput.dob),
     };
 

--- a/src/utils/excelParser.ts
+++ b/src/utils/excelParser.ts
@@ -731,12 +731,16 @@ export function parseEmployeeExcel(workbook: XLSX.WorkBook): {
         code: 'REQUIRED_FIELD',
       });
       return;
-    } else if (!/^\d{10}$/.test(mobileNumber)) {
+    } else if (!/^\d{9,10}$/.test(mobileNumber)) {
+      // Loosened from `^\d{10}$` so 9-digit MDMS-valid Kenyan numbers
+      // (`712345678`) survive parsing. EmployeeBulkImport's tenant-aware
+      // validateRow then enforces the per-tenant rule from MDMS, and
+      // `normalizeMobileForHrms` pads to 10 before HRMS submission.
       errors.push({
         row: index + 2,
         field: 'mobileNumber',
         value: mobileNumber,
-        message: 'Mobile number must be 10 digits',
+        message: 'Mobile number must be 9 or 10 digits',
         code: 'INVALID_FORMAT',
       });
     }


### PR DESCRIPTION
## Summary
Picks off the remaining BLOCKER on egovernments/CCRS#484 *and* the actual root cause of egovernments/CCRS#540 (\"Unable to create employees during onboarding\"). The reporter on #540 described it as a department error but the same impossible mobile validation was failing every row.

## What naipepea's egov-hrms actually does today
Re-verified live just before this PR landed:

```
POST /egov-hrms/employees/_create  with mobileNumber=…
  712345678   → 202 Accepted
  777777777   → 400 ERR_HRMS_USER_EXIST_MOB        (duplicate, not pattern)
  0712345678  → 400 INVALID_MOBILE_FORMAT + INVALID_MOBILE_LENGTH
                  \"must not exceed 9 digits\"
```

The `Pattern.employeeRequest.employees[0].user.mobileNumber` Bean-Validation key is gone. Validation now flows through egov-user's `MobileNumberValidator`, which reads MDMS-v2 `ValidationConfigs.mobileNumberValidation` directly — same approach that's been on `Digit-Core` master for a while.

## What the configurator was doing wrong
`useMobileValidator` and the bulk-import validator both clamped `minLength = max(mdmsMin, 10)` to respect HRMS's old `@Pattern(\"^[0-9]{10}$\")`. With the Kenya MDMS rule (`min=max=9`), that produced the impossible validator range \"length ≥ 10 AND ≤ 9\" — every input failed. The earlier commits on this branch tried to work around it by swapping in a `^0?[17][0-9]{8}$` FALLBACK and auto-padding `712345678` → `0712345678` at submission. That worked yesterday, but today HRMS rejects the padded 10-digit form, so the auto-pad has flipped from \"fix\" to \"break\".

## Fix in this PR
Drop the workaround. Trust MDMS:

| File | Change |
|---|---|
| `useMobileValidator.ts` | Removed `HRMS_MIN_LENGTH = 10` clamp, removed FALLBACK pattern swap, removed `normalizeMobileForHrms` helper. `parseRules` returns MDMS values verbatim. `FALLBACK` reset to the canonical naipepea seed (`^[17][0-9]{8}$`, min=max=9). |
| `EmployeeBulkImport.tsx` | Validator now uses `mobileRules.{minLength, maxLength, pattern}` directly — no clamp arithmetic. `createOne` sends `row.mobileNumber` raw. |
| `EmployeeCreate.tsx` | Transform sends user-typed mobileNumber raw. |
| `excelParser.ts` | Kept the loosened `^\\d{9,10}$` gate at the parser so the parser doesn't second-guess tenant rules; per-tenant length enforcement is the row validator's job. |

## Net effect for an operator on naipepea
- Form + bulk import accept exactly the MDMS rule (9-digit Kenya: `^[17][0-9]{8}$`).
- 10-digit legacy input rejected at the validator with the Kenya error message.
- HRMS receives whatever passes validation, unmodified.

## Test plan
- [ ] Configurator on naipepea: Create Employee with `712345678` → form passes, HRMS create succeeds.
- [ ] Same with `0712345678` → form rejects with the Kenya error (validator-only; never reaches HRMS).
- [ ] Phase 4 bulk import: row with valid 9-digit Kenya number + valid dept/desig → ingests successfully.
- [ ] Same row with 10-digit number → rejected with Kenya error.
- [x] `npx tsc --noEmit` clean.

Refs: egovernments/Citizen-Complaint-Resolution-System#484
      egovernments/Citizen-Complaint-Resolution-System#540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Mobile number validation now supports both 9 and 10-digit formats for improved regional compatibility
  * Employee bulk import mobile validation updated to use dynamic validation rules
  * Enhanced flexibility in mobile number validation across the system

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChakshuGautam/digit-configurator/pull/63)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->