### PR TITLE
feat(complaint-types): seed SERVICEDEFS locale keys on create

### DIFF
--- a/src/admin/DigitCreate.tsx
+++ b/src/admin/DigitCreate.tsx
@@ -43,6 +43,11 @@ export interface DigitCreateProps {
   redirect?: 'list' | 'edit' | 'show' | false;
   /** Optional pre-submit transform (stamp server-required nested fields, etc.) */
   transform?: TransformData;
+  /** Optional post-success side-effect — e.g. seed dependent localization
+   *  rows for the new record. Runs after create succeeds, before the
+   *  redirect. Failures are caught + surfaced as a toast; the redirect
+   *  still fires so the operator isn't stranded on the create form. */
+  afterCreate?: (data: RaRecord) => void | Promise<void>;
 }
 
 function DigitCreateContent({
@@ -115,7 +120,7 @@ function DigitCreateContent({
   );
 }
 
-export function DigitCreate({ title, children, resource, record, redirect = 'list', transform }: DigitCreateProps) {
+export function DigitCreate({ title, children, resource, record, redirect = 'list', transform, afterCreate }: DigitCreateProps) {
   const { info, capture, clear } = useMutationError();
   const contextResource = useResourceContext();
   const redirectTo = useRedirect();
@@ -132,7 +137,7 @@ export function DigitCreate({ title, children, resource, record, redirect = 'lis
       transform={transform}
       mutationOptions={{
         onError: (err) => capture(err),
-        onSuccess: (data) => {
+        onSuccess: async (data) => {
           clear();
           // Without a toast the page silently redirects to list — operators
           // have no way to tell a 200 apart from a quietly-swallowed 500
@@ -142,6 +147,22 @@ export function DigitCreate({ title, children, resource, record, redirect = 'lis
             title: `${prettyResourceSingular(effectiveResource)} created`,
             description: label !== 'Record' ? label : undefined,
           });
+          // Run any per-resource post-create side-effect (e.g. seeding
+          // localization rows for the new record). Errors don't block the
+          // redirect — the record itself was saved successfully, so the
+          // operator should still land on the list view and can re-run
+          // the side-effect manually if needed.
+          if (afterCreate && data) {
+            try {
+              await afterCreate(data as RaRecord);
+            } catch (e) {
+              toast({
+                title: 'Post-create step failed',
+                description: e instanceof Error ? e.message : String(e),
+                variant: 'destructive',
+              });
+            }
+          }
           // Manually fire the redirect since our custom onSuccess swallows
           // ra-core's default redirect side-effect. Without this the form
           // stayed populated after a successful create, leaving operators

--- a/src/api/services/localization.ts
+++ b/src/api/services/localization.ts
@@ -126,27 +126,54 @@ export const localizationService = {
   },
 
   // Create localization for a complaint type.
-  // We emit both the verbatim code and an uppercase variant for back-compat
-  // with consumers that lowercase/uppercase the serviceCode before lookup.
-  // Deduped so an already-uppercase serviceCode doesn't produce two identical
-  // rows — the backend's upsert rejects the whole batch on
-  // core.DUPLICATE_MESSAGE_IDENTITY when it sees the repeat.
+  //
+  // Emits up to four keys per record, deduped:
+  //   1. `SERVICEDEFS.<serviceCode>`        — citizen, exact-case (back-compat)
+  //   2. `SERVICEDEFS.<SERVICECODE>`        — citizen, uppercase (what the
+  //      runtime hooks actually query via `serviceCode.toUpperCase()`)
+  //   3. `SERVICEDEFS.<SERVICECODE>.<DEPT>` — employee form, department-
+  //      qualified. The employee `useServiceDefs` hook builds the key as
+  //      `SERVICEDEFS.<CODE_UPPER>.<DEPT>`; the citizen `getMenu` /
+  //      `getSubMenu` path uses just `SERVICEDEFS.<CODE_UPPER>`. Both must
+  //      resolve or one side renders the raw key (see
+  //      egovernments/Citizen-Complaint-Resolution-System#539).
+  //   4. `SERVICEDEFS.<MENUPATH_UPPER>`     — parent menu label that the
+  //      citizen top-level menu builds via `t("SERVICEDEFS." +
+  //      def.menuPath.toUpperCase())`. Without this a new menuPath renders
+  //      as the raw key in the citizen create flow.
+  //
+  // Deduped because the backend's upsert rejects the whole batch on
+  // core.DUPLICATE_MESSAGE_IDENTITY when it sees a repeat (e.g. an
+  // already-uppercase serviceCode would otherwise emit two identical rows
+  // for keys 1 and 2).
+  //
+  // `name` is the message for the serviceCode keys; `menuPath` (verbatim,
+  // since the operator's display label isn't a separate field) is used
+  // for the parent-menu key.
   buildComplaintTypeLocalizations(
     _tenantId: string,
     serviceCode: string,
     name: string,
-    locale: string = 'en_IN'
+    locale: string = 'en_IN',
+    opts: { department?: string; menuPath?: string } = {}
   ): LocalizationMessage[] {
-    const codes = new Set<string>([
-      `SERVICEDEFS.${serviceCode}`,
-      `SERVICEDEFS.${serviceCode.toUpperCase()}`,
-    ]);
-    return Array.from(codes).map((code) => ({
-      code,
-      message: name,
-      module: 'rainmaker-pgr',
-      locale,
-    }));
+    const messages: LocalizationMessage[] = [];
+    const seen = new Set<string>();
+    const push = (code: string, message: string) => {
+      if (seen.has(code)) return;
+      seen.add(code);
+      messages.push({ code, message, module: 'rainmaker-pgr', locale });
+    };
+
+    push(`SERVICEDEFS.${serviceCode}`, name);
+    push(`SERVICEDEFS.${serviceCode.toUpperCase()}`, name);
+    if (opts.department) {
+      push(`SERVICEDEFS.${serviceCode.toUpperCase()}.${opts.department.toUpperCase()}`, name);
+    }
+    if (opts.menuPath) {
+      push(`SERVICEDEFS.${opts.menuPath.toUpperCase()}`, opts.menuPath);
+    }
+    return messages;
   },
 
   // Create localization for a boundary
@@ -213,14 +240,20 @@ export const localizationService = {
     return this.upsertMessages(tenantId, locale, messages);
   },
 
-  // Upload localizations for all complaint types
+  // Upload localizations for all complaint types. `department` and
+  // `menuPath`, when present on each record, drive the emission of the
+  // dept-qualified and menuPath-parent keys — see
+  // `buildComplaintTypeLocalizations` for the full key list.
   async uploadComplaintTypeLocalizations(
     tenantId: string,
-    types: { serviceCode: string; name: string }[],
+    types: { serviceCode: string; name: string; department?: string; menuPath?: string }[],
     locale: string = 'en_IN'
   ): Promise<{ success: number; failed: number }> {
     const messages = types.flatMap((t) =>
-      this.buildComplaintTypeLocalizations(tenantId, t.serviceCode, t.name, locale)
+      this.buildComplaintTypeLocalizations(tenantId, t.serviceCode, t.name, locale, {
+        department: t.department,
+        menuPath: t.menuPath,
+      })
     );
     return this.upsertMessages(tenantId, locale, messages);
   },

--- a/src/resources/complaint-types/ComplaintTypeCreate.tsx
+++ b/src/resources/complaint-types/ComplaintTypeCreate.tsx
@@ -1,4 +1,8 @@
+import type { RaRecord } from 'ra-core';
 import { DigitCreate, DigitFormCodeInput, DigitFormInput, DigitFormSelect, v } from '@/admin';
+import { useAvailableLocales } from '@/hooks/useAvailableLocales';
+import { localizationService } from '@/api/services/localization';
+import { digitClient } from '@/providers/bridge';
 
 const defaultRecord = {
   active: true,
@@ -8,8 +12,54 @@ const defaultRecord = {
 };
 
 export function ComplaintTypeCreate() {
+  const { locales } = useAvailableLocales();
+
+  // After the MDMS record is saved, seed `SERVICEDEFS.*` localization keys
+  // for every locale the tenant declares. Without this a freshly-added
+  // complaint type renders as the raw key on at least one surface — the
+  // citizen subtype list uses `SERVICEDEFS.<CODE>` and the employee CSR
+  // form uses `SERVICEDEFS.<CODE>.<DEPT>`. Both must resolve, and prior
+  // to this seeding none of them existed (see
+  // egovernments/Citizen-Complaint-Resolution-System#539).
+  //
+  // We seed every configured locale with the operator-provided `name` as
+  // the message. Translations can be refined later via the bulk
+  // localization import/export. Skipping `sw_KE` (or any other tenant
+  // locale) would leave it rendering the raw key in Swahili UI, which is
+  // worse than a half-translated label.
+  const afterCreate = async (record: RaRecord) => {
+    const data = record as unknown as {
+      serviceCode?: string;
+      name?: string;
+      department?: string;
+      menuPath?: string;
+    };
+    const serviceCode = data.serviceCode?.trim();
+    const name = data.name?.trim();
+    if (!serviceCode || !name) return;
+
+    const tenantId = digitClient.stateTenantId;
+    if (!tenantId) return;
+
+    // Dedupe via Set in case StateInfo declares `en_IN` explicitly.
+    const targetLocales = new Set<string>([...locales.map((l) => l.value), 'en_IN']);
+
+    for (const locale of targetLocales) {
+      await localizationService.uploadComplaintTypeLocalizations(
+        tenantId,
+        [{ serviceCode, name, department: data.department, menuPath: data.menuPath }],
+        locale,
+      );
+    }
+
+    // Drop the localization service's in-memory cache so the next /_search
+    // reflects the new keys. Without this the digit-ui keeps reading the
+    // pre-write snapshot for up to the cache TTL.
+    await localizationService.cacheBust();
+  };
+
   return (
-    <DigitCreate title="Create Complaint Type" record={defaultRecord}>
+    <DigitCreate title="Create Complaint Type" record={defaultRecord} afterCreate={afterCreate}>
       <DigitFormInput source="name" label="Name" validate={v.name} />
       <DigitFormCodeInput source="serviceCode" label="Service Code" deriveFrom="name" validate={v.codeRequired} />
       <DigitFormSelect


### PR DESCRIPTION
## Summary

Pairs with [theflywheel/digit-ui-esbuild#115](https://github.com/theflywheel/digit-ui-esbuild/pull/115) to close egovernments/Citizen-Complaint-Resolution-System#539.

The per-record ComplaintType create flow wrote the MDMS record but didn't seed any localization keys, so a freshly-added type rendered as the raw key on both surfaces:

| Surface | Key the runtime queries | Status today |
|---|---|---|
| Citizen subtype list | `SERVICEDEFS.<CODE>` | not seeded → raw key |
| Employee CSR | `SERVICEDEFS.<CODE>.<DEPT>` | not seeded → raw key |

Confirmed live on naipepea: `TEST_CODE_01` exists at `ke.nairobi` with no matching `SERVICEDEFS.*` rows in either `en_IN` or `sw_KE`.

## What this PR does

1. **`localization.ts`** — `buildComplaintTypeLocalizations` gains an `opts: { department?, menuPath? }` param and emits up to four keys per locale (deduped against `core.DUPLICATE_MESSAGE_IDENTITY`):
   - `SERVICEDEFS.<serviceCode>` (citizen, exact-case back-compat)
   - `SERVICEDEFS.<SERVICECODE>` (citizen, uppercase — what runtime hooks actually query)
   - `SERVICEDEFS.<SERVICECODE>.<DEPT>` (employee form)
   - `SERVICEDEFS.<MENUPATH_UPPER>` (parent menu label)

   `uploadComplaintTypeLocalizations` threads the options through; signature is backwards-compatible (new fields are optional).

2. **`DigitCreate.tsx`** — optional `afterCreate?(data)` prop. Runs after the create succeeds, before the redirect. Errors are caught + toasted but don't trap the operator on the form (the record itself was saved).

3. **`ComplaintTypeCreate.tsx`** — wires `afterCreate` to:
   - Read `useAvailableLocales()` for the configured tenant locales (driven by `common-masters.StateInfo.languages`).
   - Loop over each locale and call `uploadComplaintTypeLocalizations` with the new `department` + `menuPath` options.
   - Cache-bust the localization service so the next `_search` reflects the new keys.

The operator-provided `name` is used as the message for every locale's seeding. Better to ship sw_KE with the English value than leave it rendering the raw key on the Swahili UI — operator can refine via the bulk localization editor.

## Out of scope (intentional)

- **Edit flow.** If the operator later renames a complaint type, the existing locale rows still carry the old message. Worth a follow-up.
- **Bulk Phase 3 path.** I extended the signature so `uploadComplaintTypeLocalizations` can take dept/menuPath, but `Phase3Page.tsx`'s call still only passes `serviceCode` + `name` + `en_IN`. Bulk import is high-risk for onboarding — separate follow-up.

## Test plan

After deploy + bundle swap on naipepea:

- [ ] Configurator → Complaint types → Create with `serviceCode=LOCALE_TEST_01`, `name="Locale Test"`, dept=DEPT_03, menuPath="LocaleTest". Verify toast says "Complaint type created".
- [ ] `curl /localization/messages/v1/_search?tenantId=ke.nairobi&module=rainmaker-pgr&locale=en_IN` and confirm: `SERVICEDEFS.LOCALE_TEST_01`, `SERVICEDEFS.LOCALE_TEST_01.DEPT_03`, `SERVICEDEFS.LOCALETEST` — all present with message "Locale Test" / "LocaleTest".
- [ ] Same call with `locale=sw_KE` — same rows present (same messages, since the operator only supplied English).
- [ ] Citizen UI → Create complaint → "LocaleTest" menu visible → subtype "Locale Test" visible (companion PR #115 in digit-ui-esbuild also required for this).
- [ ] Employee CSR Create complaint → subtype "Locale Test" visible under its department.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced complaint type creation with automatic localization key generation for multiple locales and variants.
  * Added support for department and menu path context in localization data, enabling richer, contextual translations.
  * Improved callback system for post-creation operations with error handling via toast notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChakshuGautam/digit-configurator/pull/65)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->