### PR TITLE
fix(phase3): write masters at state root + surface per-row failures

### DIFF
--- a/src/api/services/tenantBootstrap.ts
+++ b/src/api/services/tenantBootstrap.ts
@@ -56,6 +56,15 @@ export interface BootstrapProgress {
 // the new tenant (their @PostConstruct init evaluates these).
 const ESSENTIAL_DATA_SCHEMAS = [
   'ACCESSCONTROL-ROLES.roles',
+  // ACCESSCONTROL-ROLEACTIONS + ACCESSCONTROL-ACTIONS-TEST are read on
+  // digit-ui's employee landing — without them, the JSONPath lookup
+  // `MdmsRes.ACCESSCONTROL-ROLEACTIONS.roleactions` throws
+  // PathNotFoundException and the page renders blank. Roles alone aren't
+  // enough; the per-role action mapping (~384 rows from pg) decides what
+  // sidebar/cards each role sees, and the action definitions (~253 rows)
+  // are what those mappings reference by id.
+  'ACCESSCONTROL-ROLEACTIONS.roleactions',
+  'ACCESSCONTROL-ACTIONS-TEST.actions-test',
   'common-masters.IdFormat',
   'common-masters.Department',
   'DataSecurity.DecryptionABAC',

--- a/src/pages/Phase3Page.tsx
+++ b/src/pages/Phase3Page.tsx
@@ -43,6 +43,14 @@ type Step = 'landing' | 'upload' | 'preview' | 'creating-depts' | 'creating-comp
 export default function Phase3Page() {
   const { completePhase, addUndo, state } = useApp();
   const targetTenant = state.targetTenant || state.tenant;
+  // Common-masters (Department, Designation) and PGR ServiceDefs are
+  // *state-scoped* in DIGIT: schemas are registered at the state root and
+  // data lives there too, with sub-tenants inheriting via MDMS lookup. The
+  // wizard's targetTenant points at the new city ("mz.maputo"), so writing
+  // there fails with SCHEMA_DEFINITION_NOT_FOUND_ERR — mdms-v2 doesn't
+  // auto-resolve schemas up the hierarchy on `_create`. Mirror Phase 1's
+  // parentState derivation and write at the state root instead.
+  const parentState = targetTenant.includes('.') ? targetTenant.split('.')[0] : targetTenant;
   const navigate = useNavigate();
 
   const [step, setStep] = useState<Step>('landing');
@@ -123,10 +131,19 @@ export default function Phase3Page() {
       let desigsCreated = 0;
       let complaintsCreated = 0;
 
+      // Collect per-row failures across all three writes; surface them at the
+      // end so the wizard never paints "Phase 3 Complete!" when 0/N rows
+      // actually landed (the prior behaviour — Phase 3 read `success.length`
+      // and ignored `failed[]`, so a 100%-failed run still showed the green
+      // check). Tenant-scope mismatch (writes at city, schemas at state) was
+      // one path into this; any other per-row failure would have masked too.
+      type RowFailure = { kind: string; code: string; error: string };
+      const allFailures: RowFailure[] = [];
+
       if (departments.length > 0) {
         setProgressMessage('Creating departments...');
         const deptResults = await mdmsService.createDepartments(
-          targetTenant,
+          parentState,
           departments.map(d => ({
             code: d.code,
             name: d.name,
@@ -135,10 +152,13 @@ export default function Phase3Page() {
         );
         deptsCreated = deptResults.success.length;
         setCreatedDepts(deptsCreated);
+        for (const f of deptResults.failed) {
+          allFailures.push({ kind: 'Department', code: f.dept.code, error: f.error });
+        }
 
         // Create localizations for departments
         await localizationService.uploadDepartmentLocalizations(
-          targetTenant,
+          parentState,
           departments.map(d => ({ code: d.code, name: d.name })),
           'en_IN'
         );
@@ -150,7 +170,7 @@ export default function Phase3Page() {
       if (designations.length > 0) {
         setProgressMessage('Creating designations...');
         const desigResults = await mdmsService.createDesignations(
-          targetTenant,
+          parentState,
           designations.map(d => ({
             code: d.code,
             name: d.name,
@@ -161,10 +181,13 @@ export default function Phase3Page() {
         );
         desigsCreated = desigResults.success.length;
         setCreatedDesigs(desigsCreated);
+        for (const f of desigResults.failed) {
+          allFailures.push({ kind: 'Designation', code: f.desig.code, error: f.error });
+        }
 
         // Create localizations for designations
         await localizationService.uploadDesignationLocalizations(
-          targetTenant,
+          parentState,
           designations.map(d => ({ code: d.code, name: d.name })),
           'en_IN'
         );
@@ -182,7 +205,7 @@ export default function Phase3Page() {
       if (complaintTypes.length > 0) {
         setProgressMessage('Creating complaint types...');
         const complaintResults = await mdmsService.createComplaintTypes(
-          targetTenant,
+          parentState,
           complaintTypes.map(ct => ({
             serviceCode: ct.serviceCode,
             name: ct.name,
@@ -194,10 +217,13 @@ export default function Phase3Page() {
         );
         complaintsCreated = complaintResults.success.length;
         setCreatedComplaints(complaintsCreated);
+        for (const f of complaintResults.failed) {
+          allFailures.push({ kind: 'ComplaintType', code: f.type.serviceCode, error: f.error });
+        }
 
         // Create localizations for complaint types
         await localizationService.uploadComplaintTypeLocalizations(
-          targetTenant,
+          parentState,
           complaintTypes.map(ct => ({
             serviceCode: ct.serviceCode,
             name: ct.name,
@@ -209,6 +235,28 @@ export default function Phase3Page() {
       }
 
       addUndo('create_complaints', `Created ${complaintsCreated} complaint types`);
+
+      // If every write failed, treat the phase as failed, not complete.
+      // Partial success still advances (some rows may legitimately collide
+      // on retry); zero success with any rows attempted is the lying-banner
+      // pathology we're fixing.
+      const totalAttempted = departments.length + designations.length + complaintTypes.length;
+      const totalSucceeded = deptsCreated + desigsCreated + complaintsCreated;
+      if (totalAttempted > 0 && totalSucceeded === 0) {
+        const firstError = allFailures[0]?.error ?? 'no rows landed';
+        throw new Error(
+          `Phase 3 wrote 0 of ${totalAttempted} rows. First error: ${firstError}. ` +
+          `Check that the target state (${parentState}) has the relevant schemas registered.`
+        );
+      }
+      if (allFailures.length > 0) {
+        const summary = allFailures
+          .slice(0, 5)
+          .map(f => `${f.kind}/${f.code}: ${f.error}`)
+          .join(' • ');
+        const more = allFailures.length > 5 ? ` (+${allFailures.length - 5} more)` : '';
+        setError(`${totalSucceeded}/${totalAttempted} rows landed. Failures: ${summary}${more}`);
+      }
       setStep('complete');
     } catch (err) {
       console.error('MDMS creation error:', err);


### PR DESCRIPTION
## Summary

Phase 3 was painting "Phase 3 Complete!" with a green check even when **zero** rows from the XLSX landed at MDMS. Two bugs converged:

1. **Wrong target tenant.** Phase 3 wrote at `targetTenant` (the new city, e.g. `mz.maputo`), but `common-masters.Department`, `common-masters.Designation`, and `RAINMAKER-PGR.ServiceDefs` are *state-scoped* schemas. PR #62's bootstrap correctly clones schemas to the state root only — mdms-v2 does **not** auto-resolve schemas up the tenant hierarchy on `_create`, so every Phase 3 write returned `SCHEMA_DEFINITION_NOT_FOUND_ERR`. Mirror Phase 1's `parentState = targetTenant.split('.')[0]` and write there instead.
2. **Silent per-row failures.** `mdmsService.create{Departments,Designations,ComplaintTypes}` catches per-row errors and returns `{success, failed}`. Phase 3 only read `success.length` and never inspected `failed`, so a 100%-failed run still called `setStep('complete')` and showed the green banner.

## Repro on a freshly-onboarded `mz.maputo` before this fix

```
tenantid='mz.maputo'  → 0 rows of anything
tenantid='mz'         → 13 Department, 29 Designation, 33 ServiceDef
                        (just the pg defaults the bootstrap cloned —
                         none of the user's XLSX codes)
```

After this fix Phase 3 writes at `mz` and the XLSX codes land. If anything fails, the wizard now refuses to advance silently — if 0 of N rows succeeded it throws with the first error; partial-success runs render a destructive alert listing the failed codes.

## Test plan
- [x] Type-checks cleanly
- [x] Built dist serves locally
- [ ] Run Phase 1 → Phase 3 with a fresh state root, confirm DB rows land at `parentState`
- [ ] Run Phase 3 with a deliberately bad row (e.g. duplicate code) and confirm the failure list surfaces instead of "Complete!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for bulk data uploads to prevent operations from incorrectly showing as complete when all rows fail to process.
  * Enhanced error messages now display aggregated failure information across all row types, including succeeded/attempted counts and detailed error specifics for the first failures encountered, enabling better troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChakshuGautam/digit-configurator/pull/66)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->