### PR TITLE
fix(phase4): success screen says username is the employee code, not the name

### DIFF
--- a/src/pages/Phase4Page.tsx
+++ b/src/pages/Phase4Page.tsx
@@ -788,7 +788,7 @@ export default function Phase4Page() {
               </p>
               <ul className="space-y-1">
                 <li>• HRMS employee record</li>
-                <li>• User account (username: lowercase name)</li>
+                <li>• User account (username: employee code)</li>
                 <li>
                   • Password: <code className="bg-muted px-1 rounded text-xs text-primary">eGov@123</code>
                 </li>


### PR DESCRIPTION
## Problem

The Phase 4 (Employee Onboarding) success screen tells the operator:

> • User account (username: lowercase name)

This is wrong. The configurator sends a name-derived `userName`, but **HRMS overrides `userName` with the `employeeCode`** on create. So the credential the operator is shown does not work — login only succeeds with the employee code.

## Evidence (live, fresh `mz.maputo` onboarding)

`POST /user/oauth/token` (`Basic egov-user-client:` empty secret), `password=eGov@123`, `tenantId=mz.maputo`, `userType=EMPLOYEE`:

| username tried | result |
|---|---|
| `jane doe` / `janedoe` / `jane.doe` | `400 Invalid login credentials` |
| **`EMP001`** (the employeeCode) | **`200` + access_token** (roles `EMPLOYEE`,`GRO` @ `mz.maputo`) |

## Fix

One-line correction of the static help text: `(username: lowercase name)` → `(username: employee code)`.

The **Download Credentials CSV** is unaffected — it reads `emp.user.userName` from the HRMS create response (the server-set code), so it was already correct. No test pins this string.

## Follow-up (intentionally not in this PR)

`hrms.createEmployee` pre-checks uniqueness on the *name-derived* userName (`checkUsernameAvailable`) — a key HRMS will not use. That guard is on the wrong key and is a deeper correctness change requiring live validation; tracked separately, not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that employee user account usernames are generated based on the employee code rather than a lowercase name format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChakshuGautam/digit-configurator/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->